### PR TITLE
MAINT: Simpler inheritance

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,6 +1,8 @@
 API Reference
 -------------
 
+.. contents::
+   :local:
 
 Background Plotter
 ~~~~~~~~~~~~~~~~~~
@@ -25,7 +27,6 @@ Background Plotter
 QtInteractor
 ~~~~~~~~~~~~
 
-
 .. rubric:: Attributes
 
 .. autoautosummary:: pyvistaqt.QtInteractor
@@ -40,3 +41,9 @@ QtInteractor
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+Class inheritance
+~~~~~~~~~~~~~~~~~
+
+.. automodule:: pyvistaqt.plotting

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -1,35 +1,40 @@
-"""Qt interactive plotter.
+"""
+Diagram
+^^^^^^^
 
-Inheritance
-===========
+.. code-block:: none
 
-BackgroundPlotter
-+-- QtInteractor
-    |-- QVTKRenderWindowInteractor
-    |   +-- QWidget
-    +-- BasePlotter
+    BackgroundPlotter
+    +-- QtInteractor
+        |-- QVTKRenderWindowInteractor
+        |   +-- QWidget
+        +-- BasePlotter
 
-MainWindow
-+-- QMainWindow
+    MainWindow
+    +-- QMainWindow
 
-Usage
-=====
-BackgroundPlotter.__init__(...)
-|-- self.app_window = MainWindow()
-|-- self.frame = QFrame(parent=self.app_window)
-+-- QtInteractor.__init__(parent=self.frame)
-    |-- QVTKRenderWindowInteractor.__init__(parent=parent)
-    |   +-- QWidget.__init__(parent, flags)
-    |-- BasePlotter.__init__(...)
-    +-- self.ren_win = self.GetRenderWindow()
+Implementation
+^^^^^^^^^^^^^^
 
-Because QVTKRenderWindowInteractor calls QWidget.__init__, this will actually
-trigger BasePlotter.__init__ to be called with no arguments. This cannot be
-solved (at least) because using `super()` because
-QVTKRenderWindowInteractor.__init__ does not use super() (also it might not
-be fixable because Qt is doing something in QWidget which is probably separate
-from the super() process). We can fix this by preventing BasePlotter.__init__
-by being called by temporarily monkey-patching it with a no-op __init__.
+.. code-block:: none
+
+    BackgroundPlotter.__init__(...)
+    |-- self.app_window = MainWindow()
+    |-- self.frame = QFrame(parent=self.app_window)
+    +-- QtInteractor.__init__(parent=self.frame)
+        |-- QVTKRenderWindowInteractor.__init__(parent=parent)
+        |   +-- QWidget.__init__(parent, flags)
+        |-- BasePlotter.__init__(...)
+        +-- self.ren_win = self.GetRenderWindow()
+
+Because ``QVTKRenderWindowInteractor`` calls ``QWidget.__init__``, this will
+actually trigger ``BasePlotter.__init__`` to be called with no arguments.
+This cannot be solved (at least) because using ``super()`` because
+``QVTKRenderWindowInteractor.__init__`` does not use ``super()``, and also it
+might not be fixable because Qt is doing something in ``QWidget`` which is
+probably entirely separate from the Python ``super()`` process.
+We fix this by internally by temporarily monkey-patching
+``BasePlotter.__init__`` with a no-op ``__init__``.
 """
 import contextlib
 import os
@@ -422,6 +427,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         log.debug('QtInteractor init stop')
 
     def gesture_event(self, event):
+        """Handle gesture events."""
         pinch = event.gesture(QtCore.Qt.PinchGesture)
         if pinch:
             self.camera.Zoom(pinch.scaleFactor())

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -1,9 +1,43 @@
-"""Qt interactive plotter."""
+"""Qt interactive plotter.
+
+Inheritance
+===========
+
+BackgroundPlotter
++-- QtInteractor
+    |-- QVTKRenderWindowInteractor
+    |   +-- QWidget
+    +-- BasePlotter
+
+MainWindow
++-- QMainWindow
+
+Usage
+=====
+BackgroundPlotter.__init__(...)
+|-- self.app_window = MainWindow()
+|-- self.frame = QFrame(parent=self.app_window)
++-- QtInteractor.__init__(parent=self.frame)
+    |-- QVTKRenderWindowInteractor.__init__(parent=parent)
+    |   +-- QWidget.__init__(parent, flags)
+    |-- BasePlotter.__init__(...)
+    +-- self.ren_win = self.GetRenderWindow()
+
+Because QVTKRenderWindowInteractor calls QWidget.__init__, this will actually
+trigger BasePlotter.__init__ to be called with no arguments. This cannot be
+solved (at least) because using `super()` because
+QVTKRenderWindowInteractor.__init__ does not use super() (also it might not
+be fixable because Qt is doing something in QWidget which is probably separate
+from the super() process). We can fix this by preventing BasePlotter.__init__
+by being called by temporarily monkey-patching it with a no-op __init__.
+"""
+import contextlib
 import os
 import platform
 import time
 import warnings
 from functools import wraps
+import logging
 
 import numpy as np
 import vtk
@@ -23,6 +57,9 @@ from PyQt5.QtWidgets import (QMenuBar, QVBoxLayout, QHBoxLayout,
                              QDoubleSpinBox, QFrame, QMainWindow,
                              QSlider, QAction, QDialog, QFormLayout,
                              QFileDialog)
+log = logging.getLogger('pyvistaqt')
+log.setLevel(logging.CRITICAL)
+log.addHandler(logging.StreamHandler())
 
 
 # for display bugs due to older intel integrated GPUs, setting
@@ -254,50 +291,17 @@ def pad_image(arr, max_size=400):
     return resample_image(img, max_size=max_size)
 
 
-class QVTKRenderWindowInteractorAdapter(QObject):
-    """Adapter class for QVTKRenderWindowInteractor that uses super()."""
-
-    def __init__(self, parent, **kwargs):
-        """Initialize the internal interactor."""
-        self.interactor = QVTKRenderWindowInteractor(parent=parent)
-        self.interactor.dragEnterEvent = self.dragEnterEvent
-        self.interactor.dropEvent = self.dropEvent
-        super(QVTKRenderWindowInteractorAdapter, self).__init__(**kwargs)
-
-    def GetRenderWindow(self):
-        """Get the render window."""
-        return self.interactor.GetRenderWindow()
-
-    def setWindowTitle(self, title):
-        """Set the window title."""
-        return self.interactor.setWindowTitle(title)
-
-    def SetInteractorStyle(self, style):
-        """Set the interactor style."""
-        return self.interactor.SetInteractorStyle(style)
-
-    def show(self):
-        """Show the window."""
-        return self.interactor.show()
-
-    def close(self):
-        """Close the window."""
-        return self.interactor.close()
-
-    def setAcceptDrops(self, state):
-        """Enable drop event or not."""
-        self.interactor.setAcceptDrops(state)
-
-    def dragEnterEvent(self, event):
-        """Manage drag event."""
-        pass
-
-    def dropEvent(self, event):
-        """Manage drop event."""
-        pass
+@contextlib.contextmanager
+def _no_BasePlotter_init():
+    init = BasePlotter.__init__
+    BasePlotter.__init__ = lambda x: None
+    try:
+        yield
+    finally:
+        BasePlotter.__init__ = init
 
 
-class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
+class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     """Extend QVTKRenderWindowInteractor class.
 
     This adds the methods available to pyvista.Plotter.
@@ -339,8 +343,19 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
                  point_smoothing=False, polygon_smoothing=False,
                  splitting_position=None, auto_update=5.0, **kwargs):
         """Initialize Qt interactor."""
-        super(QtInteractor, self).__init__(parent=parent, **kwargs)
-        self.parent = parent
+        log.debug('QtInteractor init start')
+        # Cannot use super() here because
+        # QVTKRenderWindowInteractor silently swallows all kwargs
+        # because they use **kwargs in their constructor...
+        qvtk_kwargs = dict(parent=parent)
+        for key in ('stereo', 'iren', 'rw', 'wflags'):
+            if key in kwargs:
+                qvtk_kwargs[key] = kwargs.pop(key)
+        with _no_BasePlotter_init():
+            QVTKRenderWindowInteractor.__init__(self, **qvtk_kwargs)
+        BasePlotter.__init__(self, **kwargs)
+        # backward compat for when we had this as a separate class
+        self.interactor = self
 
         if multi_samples is None:
             multi_samples = rcParams['multi_samples']
@@ -402,8 +417,9 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
                 for renderer in self.renderers:
                     renderer.enable_depth_peeling()
 
-        self._first_time = False # Crucial!
+        self._first_time = False  # Crucial!
         self.view_isometric()
+        log.debug('QtInteractor init stop')
 
     def gesture_event(self, event):
         pinch = event.gesture(QtCore.Qt.PinchGesture)
@@ -560,7 +576,7 @@ class QtInteractor(QVTKRenderWindowInteractorAdapter, BasePlotter):
         if hasattr(self, "render_timer"):
             self.render_timer.stop()
         BasePlotter.close(self)
-        QVTKRenderWindowInteractorAdapter.close(self)
+        QVTKRenderWindowInteractor.close(self)
 
 
 class BackgroundPlotter(QtInteractor):
@@ -632,6 +648,7 @@ class BackgroundPlotter(QtInteractor):
                  off_screen=None, allow_quit_keypress=True,
                  toolbar=True, menu_bar=True, **kwargs):
         """Initialize the qt plotter."""
+        log.debug('BackgroundPlotter init start')
         if not isinstance(menu_bar, bool):
             raise TypeError("Expected type for ``menu_bar`` is bool"
                             " but {} was given.".format(type(menu_bar)))
@@ -671,11 +688,15 @@ class BackgroundPlotter(QtInteractor):
         self.app_window = MainWindow()
         self.app_window.setWindowTitle(kwargs.get('title', rcParams['title']))
 
-        self.frame = QFrame()
+        self.frame = QFrame(parent=self.app_window)
         self.frame.setFrameStyle(QFrame.NoFrame)
+        self.app_window.setCentralWidget(self.frame)
+        vlayout = QVBoxLayout()
+        self.frame.setLayout(vlayout)
         super(BackgroundPlotter, self).__init__(parent=self.frame,
                                                 off_screen=off_screen,
                                                 **kwargs)
+        vlayout.addWidget(self)
         self.app_window.grabGesture(QtCore.Qt.PinchGesture)
         self.app_window.signal_gesture.connect(self.gesture_event)
         self.app_window.signal_close.connect(self._close)
@@ -690,12 +711,6 @@ class BackgroundPlotter(QtInteractor):
         self.saved_cameras_tool_bar = None
         if toolbar:
             self.add_toolbars()
-
-        vlayout = QVBoxLayout()
-        vlayout.addWidget(self.interactor)
-
-        self.frame.setLayout(vlayout)
-        self.app_window.setCentralWidget(self.frame)
 
         if off_screen is None:
             off_screen = pyvista.OFF_SCREEN
@@ -713,6 +728,7 @@ class BackgroundPlotter(QtInteractor):
 
         # Keypress events
         self.add_key_event("S", self._qt_screenshot)  # shift + s
+        log.debug('BackgroundPlotter init stop')
 
     def reset_key_events(self):
         """Reset all of the key press events to their defaults.
@@ -844,10 +860,6 @@ class MainWindow(QMainWindow):
 
     signal_close = pyqtSignal()
     signal_gesture = pyqtSignal(QtCore.QEvent)
-
-    def __init__(self, parent=None):
-        """Initialize the main window."""
-        super(MainWindow, self).__init__(parent)
 
     def event(self, event):
         if event.type() == QtCore.QEvent.Gesture:


### PR DESCRIPTION
Working on #20 in #21 I started documenting the inheritance and realized that it could probably be simplified by killing `QVTKRenderWindowInteractorAdapter` altogether. This code:
```
import pyvista as pv
from pyvistaqt import BackgroundPlotter as Plotter
from pyvistaqt.plotting import logger
logger.setLevel(10)  # debug


p = Plotter()
p.show()
```
Outputs:
```
BackgroundPlotter init start
QtInteractor init start
BasePlotter init start
BasePlotter init stop
QtInteractor init stop
BackgroundPlotter init stop
```
Which looks like the correct init order to me.

It also:

1. explicitly parents each Qt widget created to what I think should be the correct parent.
2. documents the inheritance and construction order
3. Adds a `self.interactor = self` alias so that code (like MNE) that uses `plotter.interactor.whatever` will still work without needing to be updated.