### PR TITLE
Upload coverage after core coverage

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -146,14 +146,14 @@ jobs:
       pytest -v --cov pyvistaqt --cov-report xml
     displayName: 'Test Core API'
 
-  - script: |
-      pytest -v --doctest-modules pyvistaqt
-    displayName: 'Test Package Docstrings'
-
-  - script: |
+  - script: |  # this must be right after the core API
       bash <(curl -s https://codecov.io/bash)
     displayName: 'Upload coverage to codecov.io'
     condition: eq(variables['python.version'], '3.7')
+
+  - script: |
+      pytest -v --doctest-modules pyvistaqt
+    displayName: 'Test Package Docstrings'
 
   - script: |
       pip install twine


### PR DESCRIPTION
Fixes codecov report by uploading the coverage report after testing the core api.  Otherwise, the coverage gets overwritten with the docstring testing and that's uploaded instead (showing no coverage).