### PR TITLE
Add Makefile targets for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ coverage:
 	@pytest -v --cov pyvistaqt
 
 coverage-xml:
-	@echo "Running coverage"
+	@echo "Reporting XML coverage"
 	@pytest -v --cov pyvistaqt --cov-report xml
 
 coverage-html:
-	@echo "Running coverage"
+	@echo "Reporting HTML coverage"
 	@pytest -v --cov pyvistaqt --cov-report html

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,15 @@ codespell:
 pydocstyle:
 	@echo "Running pydocstyle"
 	@pydocstyle pyvista
+
+coverage:
+	@echo "Running coverage"
+	@pytest -v --cov pyvistaqt
+
+coverage-xml:
+	@echo "Running coverage"
+	@pytest -v --cov pyvistaqt --cov-report xml
+
+coverage-html:
+	@echo "Running coverage"
+	@pytest -v --cov pyvistaqt --cov-report html


### PR DESCRIPTION
This small PR brings some conveniance targets to the `Makefile`.

It's just so much easier to type `make coverage` instead of remembering the full command everytime.