### PR TITLE
Add basic Editor

### DIFF
--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -76,6 +76,24 @@ class Editor(QDialog):
 
 def _get_renderer_widget(renderer):
     widget = QWidget()
+    layout = QVBoxLayout()
+
+    # axes
+    def _axes_callback(state):
+        if state:
+            renderer.show_axes()
+        else:
+            renderer.hide_axes()
+
+    axes = QCheckBox("Axes")
+    if hasattr(renderer, "axes_widget"):
+        axes.setChecked(renderer.axes_widget.GetEnabled())
+    else:
+        axes.setChecked(False)
+    axes.toggled.connect(_axes_callback)
+    layout.addWidget(axes)
+
+    widget.setLayout(layout)
     return widget
 
 

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -45,8 +45,7 @@ class Editor(QDialog):
             for name, actor in renderer._actors.items():
                 if actor is not None:
                     self.list_widget.addItem(name)
-                    widget = _get_properties(actor)
-                    self.stacked_widget.addWidget(widget)
+                    self.stacked_widget.addWidget(_get_actor_widget(actor))
 
     def toggle(self):
         """Toggle the editor visibility."""
@@ -57,7 +56,7 @@ class Editor(QDialog):
             self.show()
 
 
-def _get_properties(actor):
+def _get_actor_widget(actor):
     widget = QWidget()
     layout = QVBoxLayout()
 

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -42,7 +42,8 @@ class Editor(QDialog):
         """Update the internal widget list."""
         self.list_widget.clear()
         for renderer in self.renderers:
-            for name, actor in renderer._actors.items():
+            actors = renderer._actors  # pylint: disable=protected-access
+            for name, actor in actors.items():
                 if actor is not None:
                     self.list_widget.addItem(name)
                     self.stacked_widget.addWidget(_get_actor_widget(actor))

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -5,7 +5,9 @@ This module contains the Qt scene editor.
 from PyQt5.QtWidgets import (
     QCheckBox,
     QDialog,
+    QDoubleSpinBox,
     QHBoxLayout,
+    QLabel,
     QListWidget,
     QStackedWidget,
     QVBoxLayout,
@@ -16,10 +18,10 @@ from PyQt5.QtWidgets import (
 class Editor(QDialog):
     """Basic scene editor."""
 
-    def __init__(self, parent, actors):
+    def __init__(self, parent, renderers):
         """Initialize the Editor."""
         super().__init__(parent=parent)
-        self.actors = actors
+        self.renderers = renderers
 
         self.list_widget = QListWidget()
         self.stacked_widget = QStackedWidget()
@@ -39,11 +41,12 @@ class Editor(QDialog):
     def update(self):
         """Update the internal widget list."""
         self.list_widget.clear()
-        for name, actor in self.actors.items():
-            if actor is not None:
-                self.list_widget.addItem(name)
-                widget = _get_properties(actor)
-                self.stacked_widget.addWidget(widget)
+        for renderer in self.renderers:
+            for name, actor in renderer._actors.items():
+                if actor is not None:
+                    self.list_widget.addItem(name)
+                    widget = _get_properties(actor)
+                    self.stacked_widget.addWidget(widget)
 
     def toggle(self):
         """Toggle the editor visibility."""
@@ -58,11 +61,24 @@ def _get_properties(actor):
     widget = QWidget()
     layout = QVBoxLayout()
 
+    prop = actor.GetProperty()
+
     # visibility
     visibility = QCheckBox("Visibility")
     visibility.setChecked(actor.GetVisibility())
     visibility.toggled.connect(actor.SetVisibility)
     layout.addWidget(visibility)
+
+    if prop is not None:
+        # opacity
+        tmp_layout = QHBoxLayout()
+        opacity = QDoubleSpinBox()
+        opacity.setMaximum(1.0)
+        opacity.setValue(prop.GetOpacity())
+        opacity.valueChanged.connect(prop.SetOpacity)
+        tmp_layout.addWidget(QLabel("Opacity"))
+        tmp_layout.addWidget(opacity)
+        layout.addLayout(tmp_layout)
 
     widget.setLayout(layout)
     return widget

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -2,14 +2,22 @@
 This module contains the Qt scene editor.
 """
 
-from PyQt5.QtWidgets import (QListWidget, QStackedWidget,
-                             QDialog, QHBoxLayout, QWidget,
-                             QVBoxLayout, QCheckBox)
+from PyQt5.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QHBoxLayout,
+    QListWidget,
+    QStackedWidget,
+    QVBoxLayout,
+    QWidget,
+)
 
 
 class Editor(QDialog):
+    """Basic scene editor."""
 
     def __init__(self, parent, actors):
+        """Initialize the Editor."""
         super().__init__(parent=parent)
         self.actors = actors
 
@@ -19,8 +27,7 @@ class Editor(QDialog):
         self.layout.addWidget(self.list_widget)
         self.layout.addWidget(self.stacked_widget)
 
-        self.list_widget.currentRowChanged.connect(
-            self.stacked_widget.setCurrentIndex)
+        self.list_widget.currentRowChanged.connect(self.stacked_widget.setCurrentIndex)
         self.list_widget.setCurrentRow(0)
 
         self.setLayout(self.layout)
@@ -30,6 +37,7 @@ class Editor(QDialog):
         self.update()
 
     def update(self):
+        """Update the internal widget list."""
         self.list_widget.clear()
         for name, actor in self.actors.items():
             if actor is not None:
@@ -38,6 +46,7 @@ class Editor(QDialog):
                 self.stacked_widget.addWidget(widget)
 
     def toggle(self):
+        """Toggle the editor visibility."""
         self.update()
         if self.isVisible():
             self.hide()
@@ -52,9 +61,7 @@ def _get_properties(actor):
     # visibility
     visibility = QCheckBox("Visibility")
     visibility.setChecked(actor.GetVisibility())
-    visibility.toggled.connect(
-        lambda x: actor.SetVisibility(x)
-    )
+    visibility.toggled.connect(actor.SetVisibility)
     layout.addWidget(visibility)
 
     widget.setLayout(layout)

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -1,0 +1,61 @@
+"""
+This module contains the Qt scene editor.
+"""
+
+from PyQt5.QtWidgets import (QListWidget, QStackedWidget,
+                             QDialog, QHBoxLayout, QWidget,
+                             QVBoxLayout, QCheckBox)
+
+
+class Editor(QDialog):
+
+    def __init__(self, parent, actors):
+        super().__init__(parent=parent)
+        self.actors = actors
+
+        self.list_widget = QListWidget()
+        self.stacked_widget = QStackedWidget()
+        self.layout = QHBoxLayout()
+        self.layout.addWidget(self.list_widget)
+        self.layout.addWidget(self.stacked_widget)
+
+        self.list_widget.currentRowChanged.connect(
+            self.stacked_widget.setCurrentIndex)
+        self.list_widget.setCurrentRow(0)
+
+        self.setLayout(self.layout)
+        self.setWindowTitle("Editor")
+        self.setModal(True)
+
+        self.update()
+
+    def update(self):
+        self.list_widget.clear()
+        for name, actor in self.actors.items():
+            if actor is not None:
+                self.list_widget.addItem(name)
+                widget = _get_properties(actor)
+                self.stacked_widget.addWidget(widget)
+
+    def toggle(self):
+        self.update()
+        if self.isVisible():
+            self.hide()
+        else:
+            self.show()
+
+
+def _get_properties(actor):
+    widget = QWidget()
+    layout = QVBoxLayout()
+
+    # visibility
+    visibility = QCheckBox("Visibility")
+    visibility.setChecked(actor.GetVisibility())
+    visibility.toggled.connect(
+        lambda x: actor.SetVisibility(x)
+    )
+    layout.addWidget(visibility)
+
+    widget.setLayout(layout)
+    return widget

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -797,6 +797,9 @@ class BackgroundPlotter(QtInteractor):
             self.counters.append(counter)
 
     def add_actor(self, *args, **kwargs):
+        actor = kwargs.get('actor', None)
+        if actor is None:
+            actor = args[0]
         name = kwargs.get('name', None)
         if name is None:
             name = actor.GetAddressAsString("")

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -59,6 +59,7 @@ from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog
 from .window import MainWindow
+from .editor import Editor
 
 if scooby.in_ipython():  # pragma: no cover
     from IPython import get_ipython
@@ -523,6 +524,7 @@ class BackgroundPlotter(QtInteractor):
         allow_quit_keypress=True,
         toolbar=True,
         menu_bar=True,
+        editor=True,
         update_app_icon=False,
         **kwargs
     ):  # pylint: disable=too-many-arguments
@@ -590,6 +592,11 @@ class BackgroundPlotter(QtInteractor):
         self._menu_close_action = None
         if menu_bar:
             self.add_menu_bar()
+
+        self._actors = dict()
+        self.editor = None
+        if editor:
+            self.add_editor()
 
         # member variable for testing only
         self._view_action = None
@@ -788,6 +795,36 @@ class BackgroundPlotter(QtInteractor):
             counter.signal_finished.connect(self._callback_timer.stop)
             self._callback_timer.timeout.connect(counter.decrease)
             self.counters.append(counter)
+
+    def add_actor(self, *args, **kwargs):
+        name = kwargs.get('name', None)
+        if name is None:
+            name = actor.GetAddressAsString("")
+        actor = super().add_actor(*args, **kwargs)
+        self._actors[name] = actor[0]
+        return actor
+
+    def remove_actor(self, actor, reset_camera=False):
+        if isinstance(actor, str):
+            name = actor
+        else:
+            name = actor.GetAddressAsString("")
+        super().remove_actor(actor, reset_camera)
+        self._actors[name] = None
+        return True
+
+    def clear(self):
+        super().clear()
+        self._actors.clear()
+
+    def add_editor(self):
+        self.editor = Editor(
+            parent=self.app_window,
+            actors=self._actors
+        )
+        self._editor_action = self.main_menu.addAction(
+            "Editor", self.editor.toggle
+        )
 
 
 def _create_menu_bar(parent):

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -595,7 +595,7 @@ class BackgroundPlotter(QtInteractor):
 
         self._actors = dict()
         self.editor = None
-        if editor:
+        if editor and menu_bar:
             self.add_editor()
 
         # member variable for testing only

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -593,7 +593,6 @@ class BackgroundPlotter(QtInteractor):
         if menu_bar:
             self.add_menu_bar()
 
-        self._actors = dict()
         self.editor = None
         if editor and menu_bar:
             self.add_editor()
@@ -796,39 +795,9 @@ class BackgroundPlotter(QtInteractor):
             self._callback_timer.timeout.connect(counter.decrease)
             self.counters.append(counter)
 
-    @wraps(pyvista.Renderer.add_actor)
-    def add_actor(self, *args, **kwargs):
-        """Wrap ``pyvista.Renderer.add_floor``."""
-        actor = kwargs.get("actor", None)
-        if actor is None:
-            actor = args[0]
-        name = kwargs.get("name", None)
-        if name is None:
-            name = actor.GetAddressAsString("")
-        actor = super().add_actor(*args, **kwargs)
-        self._actors[name] = actor[0]
-        return actor
-
-    @wraps(pyvista.Renderer.remove_actor)
-    def remove_actor(self, actor, reset_camera=False):
-        """Wrap ``pyvista.Renderer.remove_floor``."""
-        if isinstance(actor, str):
-            name = actor
-        else:
-            name = actor.GetAddressAsString("")
-        super().remove_actor(actor, reset_camera)
-        self._actors[name] = None
-        return True
-
-    @wraps(pyvista.BasePlotter.clear)
-    def clear(self):
-        """Wrap ``pyvista.BasePlotter.clear``."""
-        super().clear()
-        self._actors.clear()
-
     def add_editor(self):
         """Add the editor."""
-        self.editor = Editor(parent=self.app_window, actors=self._actors)
+        self.editor = Editor(parent=self.app_window, renderers=self.renderers)
         self._editor_action = self.main_menu.addAction("Editor", self.editor.toggle)
 
 

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -796,7 +796,9 @@ class BackgroundPlotter(QtInteractor):
             self._callback_timer.timeout.connect(counter.decrease)
             self.counters.append(counter)
 
+    @wraps(pyvista.Renderer.add_actor)
     def add_actor(self, *args, **kwargs):
+        """Wrap ``pyvista.Renderer.add_floor``."""
         actor = kwargs.get("actor", None)
         if actor is None:
             actor = args[0]
@@ -807,7 +809,9 @@ class BackgroundPlotter(QtInteractor):
         self._actors[name] = actor[0]
         return actor
 
+    @wraps(pyvista.Renderer.remove_actor)
     def remove_actor(self, actor, reset_camera=False):
+        """Wrap ``pyvista.Renderer.remove_floor``."""
         if isinstance(actor, str):
             name = actor
         else:
@@ -816,11 +820,14 @@ class BackgroundPlotter(QtInteractor):
         self._actors[name] = None
         return True
 
+    @wraps(pyvista.BasePlotter.clear)
     def clear(self):
+        """Wrap ``pyvista.BasePlotter.clear``."""
         super().clear()
         self._actors.clear()
 
     def add_editor(self):
+        """Add the editor."""
         self.editor = Editor(parent=self.app_window, actors=self._actors)
         self._editor_action = self.main_menu.addAction("Editor", self.editor.toggle)
 

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -58,8 +58,8 @@ from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog
-from .window import MainWindow
 from .editor import Editor
+from .window import MainWindow
 
 if scooby.in_ipython():  # pragma: no cover
     from IPython import get_ipython

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -797,10 +797,10 @@ class BackgroundPlotter(QtInteractor):
             self.counters.append(counter)
 
     def add_actor(self, *args, **kwargs):
-        actor = kwargs.get('actor', None)
+        actor = kwargs.get("actor", None)
         if actor is None:
             actor = args[0]
-        name = kwargs.get('name', None)
+        name = kwargs.get("name", None)
         if name is None:
             name = actor.GetAddressAsString("")
         actor = super().add_actor(*args, **kwargs)
@@ -821,13 +821,8 @@ class BackgroundPlotter(QtInteractor):
         self._actors.clear()
 
     def add_editor(self):
-        self.editor = Editor(
-            parent=self.app_window,
-            actors=self._actors
-        )
-        self._editor_action = self.main_menu.addAction(
-            "Editor", self.editor.toggle
-        )
+        self.editor = Editor(parent=self.app_window, actors=self._actors)
+        self._editor_action = self.main_menu.addAction("Editor", self.editor.toggle)
 
 
 def _create_menu_bar(parent):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -122,6 +122,8 @@ def test_counter(qtbot):
 
 @pytest.mark.skipif(NO_PLOTTING, reason="Requires system to support plotting")
 def test_editor(qtbot):
+    timeout = 1000  # adjusted timeout for MacOS
+
     # editor=True by default
     plotter = BackgroundPlotter(shape=(2, 1))
     qtbot.addWidget(plotter.app_window)
@@ -135,7 +137,7 @@ def test_editor(qtbot):
 
     editor = plotter.editor
     assert not editor.isVisible()
-    with qtbot.wait_exposed(editor, timeout=500):
+    with qtbot.wait_exposed(editor, timeout=timeout):
         editor.toggle()
     assert editor.isVisible()
 
@@ -145,7 +147,7 @@ def test_editor(qtbot):
     assert top_item is not None
 
     # simulate selection
-    with qtbot.wait_signals([tree_widget.itemSelectionChanged], timeout=500):
+    with qtbot.wait_signals([tree_widget.itemSelectionChanged], timeout=timeout):
         top_item.setSelected(True)
 
     # toggle all the renderer-associated checkboxes twice


### PR DESCRIPTION
This PR follows @banesullivan's idea in https://github.com/pyvista/pyvista-support/issues/182#issuecomment-645496798 and adds a (very) basic editor of the scene actor properties.

This is still a work in progress:

*I use a tiling window manager :sweat_smile:*

![image](https://user-images.githubusercontent.com/18143289/92488522-f4375980-f1ee-11ea-9040-23c0851c5130.png)

![output](https://user-images.githubusercontent.com/18143289/92488360-bcc8ad00-f1ee-11ea-8fce-9aabd3da4525.gif)

<details>
<summary>Code snippet</summary>

```py
import pyvista as pv
from pyvistaqt import BackgroundPlotter as Plotter

p = Plotter()
p.add_mesh(pv.Cone())
p.add_mesh(pv.Sphere(), name='Sphere')
p.add_mesh(pv.Cylinder(), name='Cylinder')
```

</details>

Also relevant to https://github.com/pyvista/pyvistaqt/issues/10