### PR TITLE
Override enable/disable

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -301,13 +301,13 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     @wraps(BasePlotter.enable)
     def enable(self) -> None:
         """Wrap ``BasePlotter.enable``."""
-        self.interactor.setEnabled(True)
+        self.setEnabled(True)
         return BasePlotter.enable(self)
 
     @wraps(BasePlotter.disable)
     def disable(self) -> None:
         """Wrap ``BasePlotter.disable``."""
-        self.interactor.setDisabled(True)
+        self.setDisabled(True)
         return BasePlotter.disable(self)
 
     # pylint: disable=invalid-name,no-self-use

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -780,6 +780,12 @@ class BackgroundPlotter(QtInteractor):
             return self.disable_parallel_projection()
         return self.enable_parallel_projection()
 
+    def enable(self):
+        self.renderer.enable()
+
+    def disable(self):
+        self.renderer.enable()
+
     @property
     def window_size(self) -> Tuple[int, int]:
         """Return render window size."""

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -298,6 +298,18 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         """Override the ``render`` method to handle threading issues."""
         return self.render_signal.emit()
 
+    @wraps(BasePlotter.enable)
+    def enable(self):
+        """Wrap ``BasePlotter.enable``."""
+        self.interactor.setEnabled(True)
+        return BasePlotter.enable(self)
+
+    @wraps(BasePlotter.disable)
+    def disable(self):
+        """Wrap ``BasePlotter.disable``."""
+        self.interactor.setDisabled(True)
+        return BasePlotter.disable(self)
+
     # pylint: disable=invalid-name,no-self-use
     def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:
         """Event is called when something is dropped onto the vtk window.
@@ -779,12 +791,6 @@ class BackgroundPlotter(QtInteractor):
         if self.camera.GetParallelProjection():
             return self.disable_parallel_projection()
         return self.enable_parallel_projection()
-
-    def enable(self):
-        self.renderer.enable()
-
-    def disable(self):
-        self.renderer.enable()
 
     @property
     def window_size(self) -> Tuple[int, int]:

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -299,13 +299,13 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         return self.render_signal.emit()
 
     @wraps(BasePlotter.enable)
-    def enable(self):
+    def enable(self) -> None:
         """Wrap ``BasePlotter.enable``."""
         self.interactor.setEnabled(True)
         return BasePlotter.enable(self)
 
     @wraps(BasePlotter.disable)
-    def disable(self):
+    def disable(self) -> None:
         """Wrap ``BasePlotter.disable``."""
         self.interactor.setDisabled(True)
         return BasePlotter.disable(self)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -205,11 +205,13 @@ def test_qt_interactor(qtbot):
     assert_hasattr(vtk_widget, "render_timer", QTimer)
     # check that BasePlotter.__init__() is called
     assert_hasattr(vtk_widget, "_closed", bool)
+    assert_hasattr(vtk_widget, "renderer", vtk.vtkRenderer)
     # check that QVTKRenderWindowInteractorAdapter.__init__() is called
     assert_hasattr(vtk_widget, "interactor", QVTKRenderWindowInteractor)
 
     interactor = vtk_widget.interactor  # QVTKRenderWindowInteractor
     render_timer = vtk_widget.render_timer  # QTimer
+    renderer = vtk_widget.renderer  # vtkRenderer
 
     # ensure that self.render is called by the timer
     render_blocker = qtbot.wait_signals([render_timer.timeout], timeout=500)
@@ -227,6 +229,12 @@ def test_qt_interactor(qtbot):
     assert interactor.isVisible()
     assert render_timer.isActive()
     assert not vtk_widget._closed
+
+    # test enable/disable
+    vtk_widget.disable()
+    assert not renderer.GetInteractive()
+    vtk_widget.enable()
+    assert renderer.GetInteractive()
 
     window.close()
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -230,7 +230,7 @@ def test_qt_interactor(qtbot):
     assert render_timer.isActive()
     assert not vtk_widget._closed
 
-    # test enable/disable
+    # test enable/disable interactivity
     vtk_widget.disable()
     assert not renderer.GetInteractive()
     vtk_widget.enable()


### PR DESCRIPTION
This is an attempt to fix https://github.com/pyvista/pyvistaqt/issues/62

So far I override `enable()` and `disable()` in `BackgroundPlotter` with a naive:

```py
    def enable(self):
        self.renderer.enable()

    def disable(self):
        self.renderer.enable()
```

But this does not work :cry: 