### PR TITLE
FIX: AttributeError on close

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -242,6 +242,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
         if off_screen:
             self.ren_win.SetOffScreenRendering(1)
+            self.iren = None
         else:
             self.iren = self.ren_win.GetInteractor()
             self.iren.RemoveObservers("MouseMoveEvent")  # slows window update?

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -243,7 +243,6 @@ def test_qt_interactor(qtbot):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
-    assert not hasattr(vtk_widget, "iren")
     assert vtk_widget._closed
 
     # check that BasePlotter.__init__() is called only once
@@ -674,7 +673,6 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
-    assert not hasattr(plotter, "iren")
     assert plotter._closed
 
     # check that BasePlotter.__init__() is called only once

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from distutils.version import LooseVersion
 
 import numpy as np
 import pytest
@@ -243,6 +244,8 @@ def test_qt_interactor(qtbot):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
+    if LooseVersion(pyvista.__version__) < '0.27.0':
+        assert not hasattr(vtk_widget, "iren")
     assert vtk_widget._closed
 
     # check that BasePlotter.__init__() is called only once
@@ -673,6 +676,8 @@ def test_background_plotting_close(qtbot, close_event, empty_scene):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
+    if LooseVersion(pyvista.__version__) < '0.27.0':
+        assert not hasattr(vtk_widget, "iren")
     assert plotter._closed
 
     # check that BasePlotter.__init__() is called only once


### PR DESCRIPTION
When the `BackgroundPlotter` is used with `off_screen=True`, the `iren` attribute is not set, leading to `AttributeError` with `pyvista 0.27.0`:

```
  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvistaqt/plotting.py", line 699, in _close
    super().close()
  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvistaqt/plotting.py", line 476, in close
    BasePlotter.close(self)
  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/pyvista/plotting/plotting.py", line 2739, in close
    if self.iren is not None:
  File "/home/travis/virtualenv/python3.8.1/lib/python3.8/site-packages/vtkmodules/qt/QVTKRenderWindowInteractor.py", line 335, in __getattr__
    raise AttributeError(self.__class__.__name__ +

AttributeError: BackgroundPlotter has no attribute named iren
```