### PR TITLE
MNT: Bump version

### DIFF
--- a/pyvistaqt/_version.py
+++ b/pyvistaqt/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvistaqt."""
 # major, minor, patch
-VERSION_INFO = 0, 2, 0
+VERSION_INFO = 0, 3, 0
 
 # Nice string for the version
 __version__ = ".".join(map(str, VERSION_INFO))


### PR DESCRIPTION
This PR follows https://github.com/pyvista/pyvistaqt/pull/76#issuecomment-763725015 and bumps the minor version to `0.3.0`