### PR TITLE
Fix the camera position in subplots

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -222,6 +222,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             self.ren_win.PolygonSmoothingOn()
 
         for renderer in self.renderers:
+            renderer.view_isometric()
             self.ren_win.AddRenderer(renderer)
 
         self.render_signal.connect(self._render)
@@ -270,7 +271,6 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
                     renderer.enable_depth_peeling()
 
         self._first_time = False  # Crucial!
-        self.view_isometric()
         LOG.debug("QtInteractor init stop")
 
     def gesture_event(self, event: QGestureEvent) -> bool:


### PR DESCRIPTION
### Using `pyvista.Plotter`:

![image](https://user-images.githubusercontent.com/1608652/107764796-919f3800-6d0f-11eb-8886-f69bde9c39bc.png)

### Using `pyvistaqt.QtInteractor`:

![image](https://user-images.githubusercontent.com/1608652/107764855-a380db00-6d0f-11eb-8329-afe5eb1be3a7.png)

### Using `pyvistaqt.QtInteractor` updated:

![image](https://user-images.githubusercontent.com/1608652/107764947-c4e1c700-6d0f-11eb-9ec0-592f2b59295f.png)
