### PR TITLE
MNT: Add GHA schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - '*'
+  schedule:
+    - cron: "0 4 * * *"
 
 jobs:
   pip:


### PR DESCRIPTION
This PR adds a schedule for the GitHub Actions CIs. This will help to relieve the pain of https://github.com/pyvista/pyvistaqt/pull/76 for example. By failing early, it draws attention on maintenance at least. What do you think @pyvista/developers ?