### PR TITLE
Bump version

### DIFF
--- a/pyvistaqt/_version.py
+++ b/pyvistaqt/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvistaqt."""
 # major, minor, patch
-VERSION_INFO = 0, 4, 0
+VERSION_INFO = 0, 5, "dev0"
 
 # Nice string for the version
 __version__ = ".".join(map(str, VERSION_INFO))


### PR DESCRIPTION
This PR follows https://github.com/pyvista/pyvistaqt/pull/106 and bumps the version to `0.5.dev0`.