### PR TITLE
MAINT: More updates

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -64,7 +64,7 @@ except ImportError:  # workaround for older PyVista
             rcParams[k] = v
 
         def __getattr__(self, k):  # noqa: D105
-            return rcParams[k]
+            return rcParams[k] if k != '__wrapped__' else None
 
     global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 from pyvista.plotting.plotting import BasePlotter

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -60,10 +60,10 @@ except ImportError:  # workaround for older PyVista
     class _GlobalTheme:
         """Wrap global_theme too rcParams."""
 
-        def __setattr__(self, k, v):  # noqa: D105
+        def __setattr__(self, k: str, v: Any) -> None:  # noqa: D105
             rcParams[k] = v
 
-        def __getattr__(self, k):  # noqa: D105
+        def __getattr__(self, k: str) -> None: # noqa: D105
             return rcParams[k] if k != "__wrapped__" else None
 
     global_theme = _GlobalTheme()  # pylint: disable=invalid-name

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -64,7 +64,7 @@ except ImportError:  # workaround for older PyVista
             rcParams[k] = v
 
         def __getattr__(self, k):  # noqa: D105
-            return rcParams[k] if k != '__wrapped__' else None
+            return rcParams[k] if k != "__wrapped__" else None
 
     global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 from pyvista.plotting.plotting import BasePlotter

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -57,7 +57,7 @@ try:
 except ImportError:  # workaround for older PyVista
     from pyvista import rcParams
 
-    class GlobalTheme:
+    class _GlobalTheme:
         """Wrap global_theme too rcParams."""
 
         def __setattr__(self, k, v):  # noqa: D105
@@ -66,7 +66,7 @@ except ImportError:  # workaround for older PyVista
         def __getattr__(self, k):  # noqa: D105
             return rcParams[k]
 
-    global_theme = GlobalTheme()  # pylint: disable=invalid-name
+    global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -51,7 +51,20 @@ import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
 import vtk
-from pyvista import rcParams
+try:
+    from pyvista import global_theme
+except Exception:  # workaround for older PyVista
+    from pyvista import rcParams
+
+    class GlobalTheme:
+
+        def __setattr__(self, k, v):
+            rcParams[k] = v
+
+        def __getattr__(self, k):
+            return rcParams[k]
+
+    global_theme = GlobalTheme()
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore
@@ -213,7 +226,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         self.interactor = self
 
         if multi_samples is None:
-            multi_samples = rcParams["multi_samples"]
+            multi_samples = global_theme.multi_samples
 
         self.setAcceptDrops(True)
 
@@ -234,7 +247,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         self.render_signal.connect(self._render)
         self.key_press_event_signal.connect(super().key_press_event)
 
-        self.background_color = rcParams["background"]
+        self.background_color = global_theme.background
         if self.title:
             self.setWindowTitle(title)
 
@@ -260,7 +273,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             self.render_timer.timeout.connect(self.render)
             self.render_timer.start(twait)
 
-        if rcParams["depth_peeling"]["enabled"]:
+        if global_theme.depth_peeling["enabled"]:
             if self.enable_depth_peeling():
                 for renderer in self.renderers:
                     renderer.enable_depth_peeling()
@@ -503,7 +516,7 @@ class BackgroundPlotter(QtInteractor):
         self.allow_quit_keypress = allow_quit_keypress
 
         if window_size is None:
-            window_size = rcParams["window_size"]
+            window_size = global_theme.window_size
 
         # Remove notebook argument in case user passed it
         kwargs.pop("notebook", None)
@@ -512,7 +525,8 @@ class BackgroundPlotter(QtInteractor):
         self.app = _setup_application(app)
         self.off_screen = _setup_off_screen(off_screen)
 
-        self.app_window = MainWindow(title=kwargs.get("title", rcParams["title"]))
+        self.app_window = MainWindow(title=kwargs.get(
+            "title", global_theme.title))
         self.frame = QFrame(parent=self.app_window)
         self.frame.setFrameStyle(QFrame.NoFrame)
         vlayout = QVBoxLayout()

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -53,10 +53,11 @@ import scooby  # type: ignore
 import vtk
 try:
     from pyvista import global_theme
-except Exception:  # workaround for older PyVista
+except ImportError:  # workaround for older PyVista
     from pyvista import rcParams
 
     class GlobalTheme:
+        """Wrap global_theme too rcParams."""
 
         def __setattr__(self, k, v):
             rcParams[k] = v
@@ -64,7 +65,7 @@ except Exception:  # workaround for older PyVista
         def __getattr__(self, k):
             return rcParams[k]
 
-    global_theme = GlobalTheme()
+    global_theme = GlobalTheme()  # pylint: disable=invalid-name
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -63,7 +63,7 @@ except ImportError:  # workaround for older PyVista
         def __setattr__(self, k: str, v: Any) -> None:  # noqa: D105
             rcParams[k] = v
 
-        def __getattr__(self, k: str) -> None: # noqa: D105
+        def __getattr__(self, k: str) -> None:  # noqa: D105
             return rcParams[k] if k != "__wrapped__" else None
 
     global_theme = _GlobalTheme()  # pylint: disable=invalid-name

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -60,10 +60,10 @@ except ImportError:  # workaround for older PyVista
     class GlobalTheme:
         """Wrap global_theme too rcParams."""
 
-        def __setattr__(self, k, v):
+        def __setattr__(self, k, v):  # noqa: D105
             rcParams[k] = v
 
-        def __getattr__(self, k):
+        def __getattr__(self, k):  # noqa: D105
             return rcParams[k]
 
     global_theme = GlobalTheme()  # pylint: disable=invalid-name

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -51,6 +51,7 @@ import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
 import vtk
+
 try:
     from pyvista import global_theme
 except ImportError:  # workaround for older PyVista
@@ -526,8 +527,7 @@ class BackgroundPlotter(QtInteractor):
         self.app = _setup_application(app)
         self.off_screen = _setup_off_screen(off_screen)
 
-        self.app_window = MainWindow(title=kwargs.get(
-            "title", global_theme.title))
+        self.app_window = MainWindow(title=kwargs.get("title", global_theme.title))
         self.frame = QFrame(parent=self.app_window)
         self.frame.setFrameStyle(QFrame.NoFrame)
         vlayout = QVBoxLayout()

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -51,22 +51,6 @@ import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
 import vtk
-
-try:
-    from pyvista import global_theme
-except ImportError:  # workaround for older PyVista
-    from pyvista import rcParams
-
-    class _GlobalTheme:
-        """Wrap global_theme too rcParams."""
-
-        def __setattr__(self, k: str, v: Any) -> None:  # noqa: D105
-            rcParams[k] = v
-
-        def __getattr__(self, k: str) -> None:  # noqa: D105
-            return rcParams[k] if k != "__wrapped__" else None
-
-    global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore
@@ -95,6 +79,22 @@ from .utils import (
     _setup_off_screen,
 )
 from .window import MainWindow
+
+try:
+    from pyvista import global_theme
+except ImportError:  # workaround for older PyVista
+    from pyvista import rcParams
+
+    class _GlobalTheme:
+        """Wrap global_theme too rcParams."""
+
+        def __setattr__(self, k: str, v: Any) -> None:  # noqa: D105
+            rcParams[k] = v
+
+        def __getattr__(self, k: str) -> None:  # noqa: D105
+            return rcParams[k] if k != "__wrapped__" else None
+
+    global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 
 if scooby.in_ipython():  # pragma: no cover
     # pylint: disable=unused-import

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -9,7 +9,7 @@ import vtk
 from qtpy.QtWidgets import QAction, QFrame, QMenuBar, QToolBar, QVBoxLayout
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QTreeWidget, QStackedWidget, QCheckBox
-from pyvista import rcParams
+from pyvistaqt.plotting import global_theme
 from pyvista.plotting import Renderer
 
 import pyvistaqt
@@ -83,12 +83,12 @@ def test_depth_peeling(qtbot):
     qtbot.addWidget(plotter.app_window)
     assert not plotter.renderer.GetUseDepthPeeling()
     plotter.close()
-    rcParams["depth_peeling"]["enabled"] = True
+    global_theme.depth_peeling["enabled"] = True
     plotter = BackgroundPlotter()
     qtbot.addWidget(plotter.app_window)
     assert plotter.renderer.GetUseDepthPeeling()
     plotter.close()
-    rcParams["depth_peeling"]["enabled"] = False
+    global_theme.depth_peeling["enabled"] = False
 
 
 def test_off_screen(qtbot):


### PR DESCRIPTION
Write a little wrapper that allows us to use `global_theme.*` instead of using `rcParams`, but have it wrap to `rcParams` on older PyVista.