### PR TITLE
Improve import speed

### DIFF
--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -2,8 +2,8 @@
 
 from typing import List
 
-import vtk
 from pyvista import Renderer
+from pyvista._vtk import vtkActor
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -98,7 +98,7 @@ def _get_renderer_widget(renderer: Renderer) -> QWidget:
     return widget
 
 
-def _get_actor_widget(actor: vtk.vtkActor) -> QWidget:
+def _get_actor_widget(actor: vtkActor) -> QWidget:
     widget = QWidget()
     layout = QVBoxLayout()
 

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-try:  # backwards compatibility with pyvista<=0.29.0
+try:  # backwards compatibility with pyvista<0.29.0
     from pyvista._vtk import vtkActor
 except ImportError:  # pragma: no cover
     from vtk import vtkActor

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -3,7 +3,6 @@
 from typing import List
 
 from pyvista import Renderer
-from pyvista._vtk import vtkActor
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QCheckBox,
@@ -17,6 +16,10 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+try:  # backwards compatibility with pyvista<=0.30.0
+    from pyvista._vtk import vtkActor
+except ImportError:
+    from vtk import vtkActor
 
 from .window import MainWindow
 

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -16,7 +16,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-try:  # backwards compatibility with pyvista<=0.30.0
+try:  # backwards compatibility with pyvista<=0.29.0
     from pyvista._vtk import vtkActor
 except ImportError:
     from vtk import vtkActor

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -18,7 +18,7 @@ from qtpy.QtWidgets import (
 )
 try:  # backwards compatibility with pyvista<=0.29.0
     from pyvista._vtk import vtkActor
-except ImportError:
+except ImportError:  # pragma: no cover
     from vtk import vtkActor
 
 from .window import MainWindow

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -67,11 +67,11 @@ from qtpy.QtWidgets import (
 )
 try:
     from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
-except ImportError:
+except ImportError:  # pragma: no cover
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 try:  # backwards compatibility with pyvista<=0.29.0
     from pyvista._vtk import vtkGenericRenderWindowInteractor
-except ImportError:
+except ImportError:  # pragma: no cover
     from vtk import vtkGenericRenderWindowInteractor
 
 from .counter import Counter

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -50,7 +50,7 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
-import vtk
+from pyvista._vtk import vtkGenericRenderWindowInteractor
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore
@@ -66,7 +66,10 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+try:
+    from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+except ImportError:
+    from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog
@@ -194,7 +197,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
     # Signals must be class attributes
     render_signal = Signal()
-    key_press_event_signal = Signal(vtk.vtkGenericRenderWindowInteractor, str)
+    key_press_event_signal = Signal(vtkGenericRenderWindowInteractor, str)
 
     # pylint: disable=too-many-arguments
     def __init__(

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -69,7 +69,7 @@ try:
     from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 except ImportError:
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
-try:  # backwards compatibility with pyvista<=0.30.0
+try:  # backwards compatibility with pyvista<=0.29.0
     from pyvista._vtk import vtkGenericRenderWindowInteractor
 except ImportError:
     from vtk import vtkGenericRenderWindowInteractor

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -50,7 +50,6 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
-from pyvista._vtk import vtkGenericRenderWindowInteractor
 from pyvista.plotting.plotting import BasePlotter
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore
@@ -70,6 +69,10 @@ try:
     from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 except ImportError:
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+try:  # backwards compatibility with pyvista<=0.30.0
+    from pyvista._vtk import vtkGenericRenderWindowInteractor
+except ImportError:
+    from vtk import vtkGenericRenderWindowInteractor
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -69,7 +69,7 @@ try:
     from vtkmodules.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 except ImportError:  # pragma: no cover
     from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
-try:  # backwards compatibility with pyvista<=0.29.0
+try:  # backwards compatibility with pyvista<0.32.0
     from pyvista._vtk import vtkGenericRenderWindowInteractor
 except ImportError:  # pragma: no cover
     from vtk import vtkGenericRenderWindowInteractor


### PR DESCRIPTION
This PR switches vtk imports to either use `pyvista._vtk` or `vtkmodules`.  This results in a reduction in import time, but also permits the user to avoid including the entire `vtk` library when freezing the application with `pyinstaller` or another freezing library.

It's slightly messy because we currently allow `pyvista>=0.29.0`.  Should we raise this to `0.29.0` in the `setup.py`, we can avoid adding this in.