### PR TITLE
FIX: Safer close

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -599,7 +599,16 @@ class BackgroundPlotter(QtInteractor):
 
         """
         if not self._closed:
-            self.app_window.close()
+            # Can get:
+            #
+            #     RuntimeError: wrapped C/C++ object of type MainWindow has
+            #     been deleted
+            #
+            # So let's be safe and try/except this in case of a problem.
+            try:
+                self.app_window.close()
+            except Exception:
+                pass
 
     def _close(self) -> None:
         super().close()


### PR DESCRIPTION
Qt callbacks should never raise an error or you get a segfault:

https://github.com/mne-tools/mne-python/pull/9803/checks?check_run_id=3796599057

```
E   subprocess.CalledProcessError: Command '['/opt/hostedtoolcache/Python/3.9.7/x64/bin/python', '-uc', "import mne; mne.viz.create_3d_figure((800, 600)); backend = mne.viz.get_3d_backend(); assert backend == 'pyvistaqt', backend"]' died with <Signals.SIGABRT: 6>.
...
Traceback (most recent call last):

  File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/site-packages/pyvistaqt/plotting.py", line 602, in close

    self.app_window.close()

RuntimeError: wrapped C/C++ object of type MainWindow has been deleted
```
This PR just more safely wraps the handler in a try/except to avoid this.