### PR TITLE
Enable linking views across two Plotters

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -384,8 +384,8 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             other_views = np.asarray(other_views)
 
         if not np.issubdtype(other_views.dtype, int):
-            raise TypeError('Expected `other_views` type is int, or list or tuple of ints:'
-                        f'{other_views.dtype} is given')
+            raise TypeError('Expected `other_views` type is int, or list or tuple of ints, '
+                        f'but {other_views.dtype} is given')
 
         renderer = self.renderers[view]
         for view_index in other_views:

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -376,7 +376,6 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         pyvista's `Plotter.link_views` method.
 
         """
-
         if other_views is None:
             other_views = np.arange(len(other_plotter.renderers))
         elif isinstance(other_views, int):

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -356,6 +356,42 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         self.setDisabled(True)
         return BasePlotter.disable(self)
 
+    def link_views_across_plotters(self, other_plotter, view=0, other_views=None):
+        """Link the views' cameras across two plotters.
+
+        Parameters
+        ----------
+        other_plotter: Plotter
+            The plotter whose views will be linked.
+        view: int
+            Link the views in `other_plotter` to the this view index.
+        other_views: int | list of ints
+            Link these views from `other_plotter` to the reference view. The default
+            is None, in which case all views from `other_plotter` will be linked to
+            the reference view.
+
+        Note
+        ----
+        For linking views belonging to a single plotter, please use
+        pyvista's `Plotter.link_views` method.
+
+        """
+
+        if other_views is None:
+            other_views = np.arange(len(other_plotter.renderers))
+        elif isinstance(other_views, int):
+            other_views = np.asarray([other_views])
+        else:
+            other_views = np.asarray(other_views)
+
+        if not np.issubdtype(other_views.dtype, int):
+            raise TypeError('Expected `other_views` type is int, or list or tuple of ints:'
+                        f'{other_views.dtype} is given')
+
+        renderer = self.renderers[view]
+        for view_index in other_views:
+            other_plotter.renderers[view_index].camera = renderer.camera
+
     # pylint: disable=invalid-name,no-self-use
     def dragEnterEvent(self, event: QtGui.QDragEnterEvent) -> None:
         """Event is called when something is dropped onto the vtk window.

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from distutils.version import LooseVersion
+from typing import Type
 
 import numpy as np
 import pytest
@@ -333,7 +334,8 @@ def test_background_plotting_camera(qtbot, plotting):
     plotter.close()
 
 
-def test_link_views_across_plotters(qtbot, plotting):
+@pytest.mark.parametrize('other_views', [None, 0, [0]])
+def test_link_views_across_plotters(other_views):
 
     def _to_array(camera_position):
         return np.asarray([list(row) for row in camera_position])
@@ -344,7 +346,7 @@ def test_link_views_across_plotters(qtbot, plotting):
     plotter_two = BackgroundPlotter(off_screen=True, title='Testing Window')
     plotter_two.add_mesh(pyvista.Sphere())
 
-    plotter_one.link_views_across_plotters(plotter_two)
+    plotter_one.link_views_across_plotters(plotter_two, other_views=other_views)
 
     plotter_one.camera_position = [(0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
     np.testing.assert_allclose(
@@ -367,6 +369,9 @@ def test_link_views_across_plotters(qtbot, plotting):
             _to_array(plotter_two.camera_position),
         )
 
+    match = 'Expected `other_views` type is int, or list or tuple of ints, but float64 is given'
+    with pytest.raises(TypeError, match=match):
+        plotter_one.link_views_across_plotters(plotter_two, other_views=[0.0])
 
 @pytest.mark.parametrize('show_plotter', [
     True,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -333,6 +333,41 @@ def test_background_plotting_camera(qtbot, plotting):
     plotter.close()
 
 
+def test_link_views_across_plotters(qtbot, plotting):
+
+    def _to_array(camera_position):
+        return np.asarray([list(row) for row in camera_position])
+
+    plotter_one = BackgroundPlotter(off_screen=True, title='Testing Window')
+    plotter_one.add_mesh(pyvista.Sphere())
+
+    plotter_two = BackgroundPlotter(off_screen=True, title='Testing Window')
+    plotter_two.add_mesh(pyvista.Sphere())
+
+    plotter_one.link_views_across_plotters(plotter_two)
+
+    plotter_one.camera_position = [(0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    np.testing.assert_allclose(
+        _to_array(plotter_one.camera_position),
+        _to_array(plotter_two.camera_position),
+    )
+
+    plotter_two.camera_position = [(0.0, 0.0, 3.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+    np.testing.assert_allclose(
+        _to_array(plotter_one.camera_position),
+        _to_array(plotter_two.camera_position),
+    )
+
+    plotter_one.unlink_views()
+    plotter_one.camera_position = [(0.0, 0.0, 1.0), (0.0, 0.0, 0.0), (0.0, 1.0, 0.0)]
+
+    with pytest.raises(AssertionError):
+        np.testing.assert_allclose(
+            _to_array(plotter_one.camera_position),
+            _to_array(plotter_two.camera_position),
+        )
+
+
 @pytest.mark.parametrize('show_plotter', [
     True,
     False,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,7 +1,6 @@
 import os
 import platform
 from distutils.version import LooseVersion
-from typing import Type
 
 import numpy as np
 import pytest


### PR DESCRIPTION
### Overview

Fixes #131 

Allows to link the views of two different Plotters.

### Details

* A `link_views_across_plotters` method has been added to `pyvistaqt.plotting.QtInteractor`. It will link a view of the current QtInteractor with specified views of a second QtInteractor.

* I thought creating a new method for this rather than overloading `pyvista.plotting.plotting.BasePlotter` was a little simpler and easier to read, but I'm happy change it if you feel otherwise.

* I havent added an `unlink_views_across_plotters` method as `pyvista.plotting.plotting.BasePlotter.unlink_views` can still be used for this.

* I thought about testing but I'm not too sure how to go about it. Here's the tests for pyvista's `link_views`: https://github.com/pyvista/pyvista/blob/main/tests/plotting/test_plotting.py#L1318-L1338 Would something similar work for `link_views_across_plotters`?

* I've tried it out on something I'm developing and it seems to work okay:

https://user-images.githubusercontent.com/29753790/144042931-244586a5-6cf2-48ea-b1cc-55d985ab913e.mov


