### PR TITLE
MNT: check CIs

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -19,287 +19,312 @@ pr:
     exclude:
     - '*no-ci*'
 
-jobs:
+stages:
+
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-latest'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+        BUILD_REASON: $(Build.Reason)
+      steps:
+      - bash: |
+          git_log=`git log --format=oneline -n 1 --skip=1`
+          echo "##vso[task.setvariable variable=log]$git_log"
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: and(eq(variables.BUILD_REASON, 'PullRequest'), or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]')))
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
 
 # DESCRIPTION: Quickly check the spelling and documentation style
-- job: CodeSpellStyle
-  pool:
-    vmImage: 'ubuntu-latest'
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '3.7'
-  - script: |
-      pip install codespell pydocstyle
-      make doctest
-    displayName: 'Run doctest'
-
-
-# DESCRIPTION: Core API and doc string testing for Linux
-- job: Linux
-  pool:
-    vmImage: 'ubuntu-latest'
+- stage: Style
   variables:
-    DISPLAY: ':99.0'
-    PYVISTA_OFF_SCREEN: 'True'
-
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
-
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-    displayName: 'Use Python $(python.version)'
-
-  - script: |
-      pip install wheel --upgrade
-      python setup.py bdist_wheel
-      pip install dist/pyvistaqt*.whl
-    displayName: Build wheel and install pyvistaqt
-
-  - script: |
-      .ci/setup_headless_display.sh
-    displayName: Install headless display
-
-  - script: |
-      sudo apt-get install python3-tk
-      pip install -r requirements_test.txt
-      pip install PyQt5==5.11.3
-      python -c "import pyvista; print(pyvista.Report())"
-      which python
-      pip list
-    displayName: 'Install dependencies'
-
-  - script: |
-      pip install pytest-azurepipelines
-      pytest -v --cov pyvistaqt --cov-report xml
-    displayName: 'Test Core API'
-
-  - script: |  # this must be right after the core API
-      bash <(curl -s https://codecov.io/bash)
-    displayName: 'Upload coverage to codecov.io'
-    condition: eq(variables['python.version'], '3.7')
-
-  - script: |
-      pytest -v --doctest-modules pyvistaqt
-    displayName: 'Test Package Docstrings'
-
-  - script: |
-      pip install twine
-      python setup.py sdist
-      twine upload --skip-existing dist/pyvistaqt*
-    displayName: 'Upload to PyPi'
-    condition: and(eq(variables['python.version'], '3.7'), contains(variables['Build.SourceBranch'], 'refs/tags/'))
-    env:
-      TWINE_USERNAME: $(twine.username)
-      TWINE_PASSWORD: $(twine.password)
-      TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
-
-  # don't run job on no-ci builds
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+    AZURE_CI: 'true'
+  jobs:
+  - job: CodeSpellStyle
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.7'
+    - script: |
+        pip install codespell pydocstyle
+        make doctest
+      displayName: 'Run doctest'
 
 
-# DESCRIPTION: Core API and doc string testing across VTK versions using conda
-- job: LinuxConda
-  pool:
-    vmImage: 'ubuntu-latest'
-  variables:
-    DISPLAY: ':99.0'
-    PYVISTA_OFF_SCREEN: 'True'
-  steps:
+- stage: Test
+  jobs:
+
+  # DESCRIPTION: Core API and doc string testing for Linux
+  - job: Linux
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      DISPLAY: ':99.0'
+      PYVISTA_OFF_SCREEN: 'True'
+
+    strategy:
+      matrix:
+        Python36:
+          python.version: '3.6'
+        Python37:
+          python.version: '3.7'
+        Python38:
+          python.version: '3.8'
+
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '$(python.version)'
+      displayName: 'Use Python $(python.version)'
+
+    - script: |
+        pip install wheel --upgrade
+        python setup.py bdist_wheel
+        pip install dist/pyvistaqt*.whl
+      displayName: Build wheel and install pyvistaqt
+
     - script: |
         .ci/setup_headless_display.sh
       displayName: Install headless display
 
     - script: |
-        export CONDA_ALWAYS_YES=1
-        source /usr/share/miniconda/etc/profile.d/conda.sh
-        conda config --add channels conda-forge
-        conda env create --quiet -n pyvistaqt-env --file environment.yml
-        conda activate pyvistaqt-env
+        sudo apt-get install python3-tk
+        pip install -r requirements_test.txt
         pip install PyQt5==5.11.3
-        pip install -e .
-        conda list
+        python -c "import pyvista; print(pyvista.Report())"
         which python
-        python -c "import pyvista; print(pyvista.Report())"
-      displayName: Create Anaconda environment
+        pip list
+      displayName: 'Install dependencies'
 
     - script: |
-        source /usr/share/miniconda/etc/profile.d/conda.sh
-        conda activate pyvistaqt-env
-        pytest -v --cov pyvistaqt --cov-report html
-      displayName: 'Test Core API against VTK'
+        pip install pytest-azurepipelines
+        pytest -v --cov pyvistaqt --cov-report xml
+      displayName: 'Test Core API'
+
+    - script: |  # this must be right after the core API
+        bash <(curl -s https://codecov.io/bash)
+      displayName: 'Upload coverage to codecov.io'
+      condition: eq(variables['python.version'], '3.7')
 
     - script: |
-        source /usr/share/miniconda/etc/profile.d/conda.sh
-        conda activate pyvistaqt-env
         pytest -v --doctest-modules pyvistaqt
-      displayName: 'Test Package Docstrings against VTK'
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
-
-
-# DESCRIPTION: Core API testing for Windows
-- job: Windows
-  pool:
-    vmIMage: 'VS2017-Win2016'
-  variables:
-    AZURE_CI_WINDOWS: 'true'
-  strategy:
-    maxParallel: 4
-    matrix:
-      Python36-64bit:
-        PYTHON_VERSION: '3.6'
-      Python37-64bit:
-        PYTHON_VERSION: '3.7'
-      Python38-64bit:
-        PYTHON_VERSION: '3.8'
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: $(PYTHON_VERSION)
-      addToPath: true
-  - powershell: |
-      Set-StrictMode -Version Latest
-      $ErrorActionPreference = "Stop"
-      $PSDefaultParameterValues['*:ErrorAction']='Stop'
-      git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
-      powershell gl-ci-helpers/appveyor/install_opengl.ps1
-    displayName: 'Install OpenGL'
-  - script: |
-      python -m pip install -r requirements_test.txt
-    displayName: 'Install test dependencies'
-  - script: |
-      pip install PyQt5>=5.11
-      python -m pip install -e .
-      python -c "import pyvista; print(pyvista.Report())"
-    displayName: 'Install PyVista'
-  - script: |
-      pytest -v --cov pyvistaqt --cov-report html
-    displayName: 'Run Tests'
-
-  # don't run job on no-ci builds
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
-
-
-# DESCRIPTION: Core API testing for MacOS
-- job: macOS
-  variables:
-    python.architecture: 'x64'
-  strategy:
-    matrix:
-      Python36:
-        python.version: '3.6'
-      Python37:
-        python.version: '3.7'
-      Python38:
-        python.version: '3.8'
-  pool:
-    vmImage: 'macOS-10.15'
-  steps:
-    - script: |
-        .ci/macos-install-python.sh '$(python.version)'
-        python -c "import sys; print(sys.version)"
-      displayName: Install Python
+      displayName: 'Test Package Docstrings'
 
     - script: |
-        python -m pip install PyQt5>=5.11
-        python -m pip install -e .
-        python -c "import pyvista; print(pyvista.Report())"
-      displayName: 'Install pyvistaqt'
+        pip install twine
+        python setup.py sdist
+        twine upload --skip-existing dist/pyvistaqt*
+      displayName: 'Upload to PyPi'
+      condition: and(eq(variables['python.version'], '3.7'), contains(variables['Build.SourceBranch'], 'refs/tags/'))
+      env:
+        TWINE_USERNAME: $(twine.username)
+        TWINE_PASSWORD: $(twine.password)
+        TWINE_REPOSITORY_URL: "https://upload.pypi.org/legacy/"
 
+    # don't run job on no-ci builds
+    condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+
+
+  # DESCRIPTION: Core API and doc string testing across VTK versions using conda
+  - job: LinuxConda
+    pool:
+      vmImage: 'ubuntu-latest'
+    variables:
+      DISPLAY: ':99.0'
+      PYVISTA_OFF_SCREEN: 'True'
+    steps:
+      - script: |
+          .ci/setup_headless_display.sh
+        displayName: Install headless display
+
+      - script: |
+          export CONDA_ALWAYS_YES=1
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda config --add channels conda-forge
+          conda env create --quiet -n pyvistaqt-env --file environment.yml
+          conda activate pyvistaqt-env
+          pip install PyQt5==5.11.3
+          pip install -e .
+          conda list
+          which python
+          python -c "import pyvista; print(pyvista.Report())"
+        displayName: Create Anaconda environment
+
+      - script: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate pyvistaqt-env
+          pytest -v --cov pyvistaqt --cov-report html
+        displayName: 'Test Core API against VTK'
+
+      - script: |
+          source /usr/share/miniconda/etc/profile.d/conda.sh
+          conda activate pyvistaqt-env
+          pytest -v --doctest-modules pyvistaqt
+        displayName: 'Test Package Docstrings against VTK'
+    condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+
+
+  # DESCRIPTION: Core API testing for Windows
+  - job: Windows
+    pool:
+      vmIMage: 'VS2017-Win2016'
+    variables:
+      AZURE_CI_WINDOWS: 'true'
+    strategy:
+      maxParallel: 4
+      matrix:
+        Python36-64bit:
+          PYTHON_VERSION: '3.6'
+        Python37-64bit:
+          PYTHON_VERSION: '3.7'
+        Python38-64bit:
+          PYTHON_VERSION: '3.8'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: $(PYTHON_VERSION)
+        addToPath: true
+    - powershell: |
+        Set-StrictMode -Version Latest
+        $ErrorActionPreference = "Stop"
+        $PSDefaultParameterValues['*:ErrorAction']='Stop'
+        git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+        powershell gl-ci-helpers/appveyor/install_opengl.ps1
+      displayName: 'Install OpenGL'
     - script: |
         python -m pip install -r requirements_test.txt
-        python -m pip install pytest-azurepipelines
-        python -m pytest -v --cov pyvistaqt --cov-report html --durations=0
+      displayName: 'Install test dependencies'
+    - script: |
+        pip install PyQt5>=5.11
+        python -m pip install -e .
+        python -c "import pyvista; print(pyvista.Report())"
+      displayName: 'Install PyVista'
+    - script: |
+        pytest -v --cov pyvistaqt --cov-report html
       displayName: 'Run Tests'
 
-  # don't run job on no-ci builds
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+    # don't run job on no-ci builds
+    condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
 
-# Builds the documentation
-- job: BuildDocumentation
-  pool:
-    vmImage: 'ubuntu-latest'
+  # DESCRIPTION: Core API testing for MacOS
+  - job: MacOS
+    variables:
+      python.architecture: 'x64'
+    strategy:
+      matrix:
+        Python36:
+          python.version: '3.6'
+        Python37:
+          python.version: '3.7'
+        Python38:
+          python.version: '3.8'
+    pool:
+      vmImage: 'macOS-10.15'
+    steps:
+      - script: |
+          .ci/macos-install-python.sh '$(python.version)'
+          python -c "import sys; print(sys.version)"
+        displayName: Install Python
 
-  variables:
-    DISPLAY: ':99.0'
-    PYVISTA_OFF_SCREEN: 'True'
+      - script: |
+          python -m pip install PyQt5>=5.11
+          python -m pip install -e .
+          python -c "import pyvista; print(pyvista.Report())"
+        displayName: 'Install pyvistaqt'
 
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: 3.7
-    displayName: 'Use Python 3.7'
+      - script: |
+          python -m pip install -r requirements_test.txt
+          python -m pip install pytest-azurepipelines
+          python -m pytest -v --cov pyvistaqt --cov-report html --durations=0
+        displayName: 'Run Tests'
 
-  - script: |
-      git config --global user.name ${GH_NAME}
-      git config --global user.email ${GH_EMAIL}
-      git config --list | grep user.
-    displayName: 'Configure git'
-    env:
-      GH_NAME: $(gh.name)
-      GH_EMAIL: $(gh.email)
+    # don't run job on no-ci builds
+    condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
 
-  - script: |
-      sudo apt-get install python3-tk
-      # The following linux deps are necessary to use the builtin xcb:
-      # https://github.com/pyvista/pyvistaqt/pull/61#issuecomment-709320826
-      sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0    \
-                              libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-                              libxcb-xinerama0 libxcb-xfixes0
-      pip install -r requirements_docs.txt
-    displayName: 'Install dependencies'
 
-  - script: |
-      pip install PyQt5>=5.11
-      pip install -e .
-    displayName: Install pyvistaqt
+  # Builds the documentation
+  - job: BuildDocumentation
+    pool:
+      vmImage: 'ubuntu-latest'
 
-  - script: |
-      .ci/setup_headless_display.sh
-      # python .ci/pyvista_test.py  # for debug
-    displayName: Install headless display
+    variables:
+      DISPLAY: ':99.0'
+      PYVISTA_OFF_SCREEN: 'True'
 
-  - script: |
-      make -C docs html -b coverage
-      cat docs/_build/coverage/python.txt
-    displayName: 'Build documentation'
+    steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: 3.7
+      displayName: 'Use Python 3.7'
 
-  - script: |
-      make -C docs doctest
-    displayName: 'Test documentation code snippets'
+    - script: |
+        git config --global user.name ${GH_NAME}
+        git config --global user.email ${GH_EMAIL}
+        git config --list | grep user.
+      displayName: 'Configure git'
+      env:
+        GH_NAME: $(gh.name)
+        GH_EMAIL: $(gh.email)
 
-  - script: |
-      make -C docs html
-    displayName: 'Update figures from doctest'
+    - script: |
+        sudo apt-get install python3-tk
+        # The following linux deps are necessary to use the builtin xcb:
+        # https://github.com/pyvista/pyvistaqt/pull/61#issuecomment-709320826
+        sudo apt-get install -y libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0    \
+                                libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+                                libxcb-xinerama0 libxcb-xfixes0
+        pip install -r requirements_docs.txt
+      displayName: 'Install dependencies'
 
-  # upload documentation to pyvistaqt-docs
-  - script: |
-      git clone --depth 1 https://${GH_TOKEN}@github.com/pyvista/pyvistaqt-docs.git
-      cd pyvistaqt-docs
-      git gc --prune=now
-      git remote prune origin
-      rm -rf *
-      cp -r $BUILD_SOURCESDIRECTORY/docs/_build/html/* .
-      cp $BUILD_SOURCESDIRECTORY/docs/README.md .
-      touch .nojekyll
-      echo "qtdocs.pyvista.org" >> CNAME
-      echo $(date) > BUILD_DATETIME
-      git add .
-      git commit -am "Azure CI commit ref $(Build.SourceVersion)"
-      git push
-    displayName: Upload Documentation to pyvistaqt-docs
-    env:
-      GH_TOKEN: $(gh.token)
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    - script: |
+        pip install PyQt5>=5.11
+        pip install -e .
+      displayName: Install pyvistaqt
 
-  # don't run job on no-ci builds
-  condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))
+    - script: |
+        .ci/setup_headless_display.sh
+        # python .ci/pyvista_test.py  # for debug
+      displayName: Install headless display
+
+    - script: |
+        make -C docs html -b coverage
+        cat docs/_build/coverage/python.txt
+      displayName: 'Build documentation'
+
+    - script: |
+        make -C docs doctest
+      displayName: 'Test documentation code snippets'
+
+    - script: |
+        make -C docs html
+      displayName: 'Update figures from doctest'
+
+    # upload documentation to pyvistaqt-docs
+    - script: |
+        git clone --depth 1 https://${GH_TOKEN}@github.com/pyvista/pyvistaqt-docs.git
+        cd pyvistaqt-docs
+        git gc --prune=now
+        git remote prune origin
+        rm -rf *
+        cp -r $BUILD_SOURCESDIRECTORY/docs/_build/html/* .
+        cp $BUILD_SOURCESDIRECTORY/docs/README.md .
+        touch .nojekyll
+        echo "qtdocs.pyvista.org" >> CNAME
+        echo $(date) > BUILD_DATETIME
+        git add .
+        git commit -am "Azure CI commit ref $(Build.SourceVersion)"
+        git push
+      displayName: Upload Documentation to pyvistaqt-docs
+      env:
+        GH_TOKEN: $(gh.token)
+      condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+
+    # don't run job on no-ci builds
+    condition: not(contains(variables['System.PullRequest.SourceBranch'], 'no-ci'))

--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -58,6 +58,8 @@ stages:
 
 
 - stage: Test
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
   jobs:
 
   # DESCRIPTION: Core API and doc string testing for Linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         pyvista: ['0.30', '0.31', '0.32']
-        qt: ['PyQt5']
     defaults:
       run:
         shell: bash
@@ -85,8 +84,12 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements_test.txt
         name: 'Install dependencies with pip'
-      - run: pip install ${{ matrix.qt }}
+      - run: pip install PyQt5
         name: 'Install Qt binding'
+        if: matrix.os == 'macos-latest'
+      - run: pip install PySide2
+        name: 'Install Qt binding'
+        if: matrix.os != 'macos-latest'
       - run: pip install pyvista==${{ matrix.pyvista }}
         name: 'Install PyVista'
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         name: 'Upload coverage to CodeCov'
 
   pip:
-    name: ${{ matrix.os }} / pip / ${{ matrix.qt }} / pyvista-${{ matrix.pyvista }}
+    name: ${{ matrix.os }} / pip / pyvista-${{ matrix.pyvista }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         pyvista: ['0.30', '0.31', '0.32']
-        qt: ['PySide2']
+        qt: ['PyQt5']
     defaults:
       run:
         shell: bash
@@ -85,7 +85,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements_test.txt
         name: 'Install dependencies with pip'
-      - run: pip install PyQt5>=5.11
+      - run: pip install ${{ matrix.qt }}
         name: 'Install Qt binding'
       - run: pip install pyvista==${{ matrix.pyvista }}
         name: 'Install PyVista'
@@ -106,7 +106,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        qt: ['PySide2']
+        qt: ['PyQt5']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        pyvista: ['0.29', '0.30', '0.31']
+        pyvista: ['0.28', '0.31', '0.32']
         qt: ['PySide2']
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        pyvista: ['0.28', '0.31', '0.32']
+        pyvista: ['0.30', '0.31', '0.32']
         qt: ['PySide2']
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r requirements_test.txt
         name: 'Install dependencies with pip'
-      - run: pip install ${{ matrix.qt }}
+      - run: pip install PyQt5>=5.11
         name: 'Install Qt binding'
       - run: pip install pyvista==${{ matrix.pyvista }}
         name: 'Install PyVista'

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -20,7 +20,7 @@ from pyvistaqt.editor import Editor
 
 
 class TstWindow(MainWindow):
-    def __init__(self, parent=None, show=True, off_screen=True):
+    def __init__(self, parent=None, show=False, off_screen=False):
         MainWindow.__init__(self, parent)
 
         self.frame = QFrame()
@@ -261,13 +261,9 @@ def test_qt_interactor(qtbot, plotting):
     assert len(_ALL_PLOTTERS) == 1
 
 
-@pytest.mark.parametrize('show_plotter', [
-    True,
-    False,
-    ])
-def test_background_plotting_axes_scale(qtbot, show_plotter, plotting):
+def test_background_plotting_axes_scale(qtbot, plotting):
     plotter = BackgroundPlotter(
-        show=show_plotter,
+        show=False,
         off_screen=False,
         title='Testing Window'
     )
@@ -276,10 +272,9 @@ def test_background_plotting_axes_scale(qtbot, show_plotter, plotting):
     qtbot.addWidget(window)  # register the window
 
     # show the window
-    if not show_plotter:
-        assert not window.isVisible()
-        with qtbot.wait_exposed(window):
-            window.show()
+    assert not window.isVisible()
+    with qtbot.wait_exposed(window):
+        window.show()
     assert window.isVisible()
 
     plotter.add_mesh(pyvista.Sphere())
@@ -372,17 +367,13 @@ def test_link_views_across_plotters(other_views):
     with pytest.raises(TypeError, match=match):
         plotter_one.link_views_across_plotters(plotter_two, other_views=[0.0])
 
-@pytest.mark.parametrize('show_plotter', [
-    True,
-    False,
-    ])
-def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting):
+def test_background_plotter_export_files(qtbot, tmpdir, plotting):
     # setup filesystem
     output_dir = str(tmpdir.mkdir("tmpdir"))
     assert os.path.isdir(output_dir)
 
     plotter = BackgroundPlotter(
-        show=show_plotter,
+        show=False,
         off_screen=False,
         title='Testing Window'
     )
@@ -391,10 +382,9 @@ def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting):
     qtbot.addWidget(window)  # register the window
 
     # show the window
-    if not show_plotter:
-        assert not window.isVisible()
-        with qtbot.wait_exposed(window):
-            window.show()
+    assert not window.isVisible()
+    with qtbot.wait_exposed(window):
+        window.show()
     assert window.isVisible()
 
     plotter.add_mesh(pyvista.Sphere())
@@ -425,17 +415,13 @@ def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting):
     assert os.path.isfile(filename)
 
 
-@pytest.mark.parametrize('show_plotter', [
-    True,
-    False,
-    ])
-def test_background_plotter_export_vtkjs(qtbot, tmpdir, show_plotter, plotting):
+def test_background_plotter_export_vtkjs(qtbot, tmpdir, plotting):
     # setup filesystem
     output_dir = str(tmpdir.mkdir("tmpdir"))
     assert os.path.isdir(output_dir)
 
     plotter = BackgroundPlotter(
-        show=show_plotter,
+        show=False,
         off_screen=False,
         title='Testing Window'
     )
@@ -444,10 +430,9 @@ def test_background_plotter_export_vtkjs(qtbot, tmpdir, show_plotter, plotting):
     qtbot.addWidget(window)  # register the window
 
     # show the window
-    if not show_plotter:
-        assert not window.isVisible()
-        with qtbot.wait_exposed(window):
-            window.show()
+    assert not window.isVisible()
+    with qtbot.wait_exposed(window):
+        window.show()
     assert window.isVisible()
 
     plotter.add_mesh(pyvista.Sphere())

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -587,20 +587,13 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
         title='Testing Window',
         update_app_icon=True,  # also does add_callback
     )
+    assert_hasattr(plotter, "app_window", MainWindow)
     assert plotter._last_update_time == -np.inf
     sphere = pyvista.Sphere()
-    mycallback = CallBack(sphere)
     plotter.add_mesh(sphere)
-    plotter.add_callback(mycallback, interval=200, count=3)
-
-    # check that timers are set properly in add_callback()
-    assert_hasattr(plotter, "app_window", MainWindow)
-    assert_hasattr(plotter, "_callback_timer", QTimer)
-    assert_hasattr(plotter, "counters", list)
+    mycallback = CallBack(sphere)
 
     window = plotter.app_window  # MainWindow
-    callback_timer = plotter._callback_timer  # QTimer
-    counter = plotter.counters[-1]  # Counter
 
     # ensure that the window is showed
     assert not window.isVisible()
@@ -620,6 +613,13 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     plotter.set_icon(os.path.join(
         os.path.dirname(pyvistaqt.__file__), "data",
         "pyvista_logo_square.png"))
+
+    plotter.add_callback(mycallback, interval=200, count=3)
+    # check that timers are set properly in add_callback()
+    assert_hasattr(plotter, "_callback_timer", QTimer)
+    assert_hasattr(plotter, "counters", list)
+    callback_timer = plotter._callback_timer  # QTimer
+    counter = plotter.counters[-1]  # Counter
 
     # ensure that self.callback_timer send a signal
     callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=2000)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -265,7 +265,8 @@ def test_background_plotting_axes_scale(qtbot, plotting):
     plotter = BackgroundPlotter(
         show=False,
         off_screen=False,
-        title='Testing Window'
+        auto_update=False,
+        title='Testing Window',
     )
     assert_hasattr(plotter, "app_window", MainWindow)
     window = plotter.app_window  # MainWindow
@@ -276,6 +277,7 @@ def test_background_plotting_axes_scale(qtbot, plotting):
     with qtbot.wait_exposed(window):
         window.show()
     assert window.isVisible()
+    plotter._render()
 
     plotter.add_mesh(pyvista.Sphere())
     assert_hasattr(plotter, "renderer", Renderer)
@@ -739,7 +741,7 @@ def test_multiplotter(qtbot, plotting):
     mp.close()
 
 
-def _create_testing_scene(show=False, off_screen=False):
+def _create_testing_scene():
     plotter = BackgroundPlotter(
         shape=(2, 2),
         border=True,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -129,7 +129,7 @@ def test_counter(qtbot):
 
     counter = Counter(count=1)
     assert counter.count == 1
-    with qtbot.wait_signals([counter.signal_finished], timeout=300):
+    with qtbot.wait_signals([counter.signal_finished], timeout=1000):
         counter.decrease()
     assert counter.count == 0
 
@@ -172,7 +172,7 @@ def test_editor(qtbot, plotting):
     assert top_item is not None
 
     # simulate selection
-    with qtbot.wait_signals([tree_widget.itemSelectionChanged], timeout=1000):
+    with qtbot.wait_signals([tree_widget.itemSelectionChanged], timeout=2000):
         top_item.setSelected(True)
 
     # toggle all the renderer-associated checkboxes twice
@@ -187,9 +187,9 @@ def test_editor(qtbot, plotting):
         widget_item = page_layout.itemAt(widget_idx)
         widget = widget_item.widget()
         if isinstance(widget, QCheckBox):
-            with qtbot.wait_signals([widget.toggled], timeout=1000):
+            with qtbot.wait_signals([widget.toggled], timeout=2000):
                 widget.toggle()
-            with qtbot.wait_signals([widget.toggled], timeout=1000):
+            with qtbot.wait_signals([widget.toggled], timeout=2000):
                 widget.toggle()
 
     # hide the editor for coverage

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -224,9 +224,6 @@ def test_qt_interactor(qtbot, plotting):
     render_timer = vtk_widget.render_timer  # QTimer
     renderer = vtk_widget.renderer  # vtkRenderer
 
-    # force rendering
-    interactor._render()
-
     window.add_sphere()
     assert np.any(window.vtk_widget.mesh.points)
 
@@ -277,7 +274,6 @@ def test_background_plotting_axes_scale(qtbot, plotting):
     with qtbot.wait_exposed(window):
         window.show()
     assert window.isVisible()
-    plotter._render()
 
     plotter.add_mesh(pyvista.Sphere())
     assert_hasattr(plotter, "renderer", Renderer)
@@ -672,9 +668,6 @@ def test_background_plotting_close(qtbot, close_event, plotting):
         window.show()
     with qtbot.wait_exposed(interactor, timeout=10000):
         interactor.show()
-
-    # force rendering
-    plotter._render()
 
     # check that the widgets are showed properly
     assert window.isVisible()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -591,7 +591,7 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     sphere = pyvista.Sphere()
     mycallback = CallBack(sphere)
     plotter.add_mesh(sphere)
-    plotter.add_callback(mycallback, interval=200, count=3)
+    plotter.add_callback(mycallback, interval=1000, count=3)
 
     # check that timers are set properly in add_callback()
     assert_hasattr(plotter, "app_window", MainWindow)
@@ -622,10 +622,10 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
         "pyvista_logo_square.png"))
 
     # ensure that self.callback_timer send a signal
-    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=300)
+    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=1000)
     callback_blocker.wait()
     # ensure that self.counters send a signal
-    counter_blocker = qtbot.wait_signals([counter.signal_finished], timeout=700)
+    counter_blocker = qtbot.wait_signals([counter.signal_finished], timeout=1000)
     counter_blocker.wait()
     assert not callback_timer.isActive()  # counter stops the callback
 
@@ -633,7 +633,7 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     callback_timer = plotter._callback_timer  # QTimer
 
     # ensure that self.callback_timer send a signal
-    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=300)
+    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=1000)
     callback_blocker.wait()
 
     assert callback_timer.isActive()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -565,6 +565,7 @@ def test_background_plotting_menu_bar(qtbot, plotting):
     assert plotter._last_update_time == -np.inf
 
 
+@pytest.mark.skipif(platform.system()=="Darwin", reason="Crashes on MacOS")
 def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     class CallBack(object):
         def __init__(self, sphere):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -268,7 +268,7 @@ def test_background_plotting_axes_scale(qtbot, show_plotter, plotting):
     plotter = BackgroundPlotter(
         show=show_plotter,
         off_screen=False,
-        title='Testing Window',
+        title='Testing Window'
     )
     assert_hasattr(plotter, "app_window", MainWindow)
     window = plotter.app_window  # MainWindow
@@ -422,6 +422,7 @@ def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting):
     plotter.close()
     assert not window.isVisible()
     assert os.path.isfile(filename)
+
 
 @pytest.mark.parametrize('show_plotter', [
     True,
@@ -771,7 +772,7 @@ def _create_testing_scene(empty_scene, show=False, off_screen=False):
             border_width=10,
             border_color='grey',
             show=show,
-            off_screen=off_screen,
+            off_screen=off_screen
         )
         plotter.set_background('black', top='blue')
         plotter.subplot(0, 0)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -565,7 +565,6 @@ def test_background_plotting_menu_bar(qtbot, plotting):
     assert plotter._last_update_time == -np.inf
 
 
-@pytest.mark.skipif(platform.system()=="Darwin", reason="Crashes on MacOS")
 def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     class CallBack(object):
         def __init__(self, sphere):
@@ -590,6 +589,7 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     )
     assert_hasattr(plotter, "app_window", MainWindow)
     assert_hasattr(plotter, "_callback_timer", QTimer)
+    assert_hasattr(plotter, "counters", list)
     assert plotter._last_update_time == -np.inf
 
     sphere = pyvista.Sphere()
@@ -624,7 +624,6 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     plotter.add_callback(mycallback, interval=200, count=3)
     callback_timer = plotter._callback_timer  # QTimer
     assert callback_timer.isActive()
-    assert_hasattr(plotter, "counters", list)
     counter = plotter.counters[-1]  # Counter
 
     # ensure that self.callback_timer send a signal

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -591,7 +591,7 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     sphere = pyvista.Sphere()
     mycallback = CallBack(sphere)
     plotter.add_mesh(sphere)
-    plotter.add_callback(mycallback, interval=1000, count=3)
+    plotter.add_callback(mycallback, interval=200, count=3)
 
     # check that timers are set properly in add_callback()
     assert_hasattr(plotter, "app_window", MainWindow)
@@ -622,10 +622,10 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
         "pyvista_logo_square.png"))
 
     # ensure that self.callback_timer send a signal
-    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=1000)
+    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=2000)
     callback_blocker.wait()
     # ensure that self.counters send a signal
-    counter_blocker = qtbot.wait_signals([counter.signal_finished], timeout=1000)
+    counter_blocker = qtbot.wait_signals([counter.signal_finished], timeout=2000)
     counter_blocker.wait()
     assert not callback_timer.isActive()  # counter stops the callback
 
@@ -633,7 +633,7 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     callback_timer = plotter._callback_timer  # QTimer
 
     # ensure that self.callback_timer send a signal
-    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=1000)
+    callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=2000)
     callback_blocker.wait()
 
     assert callback_timer.isActive()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -747,9 +747,9 @@ def _create_testing_scene():
         border=True,
         border_width=10,
         border_color='grey',
-        show=show,
+        show=False,
         auto_update=False,  # prevent untimely updates
-        off_screen=off_screen,
+        off_screen=False,
     )
     plotter.set_background('black', top='blue')
     plotter.subplot(0, 0)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -260,6 +260,7 @@ def test_qt_interactor(qtbot, plotting):
     # check that BasePlotter.__init__() is called only once
     assert len(_ALL_PLOTTERS) == 1
 
+
 @pytest.mark.parametrize('show_plotter', [
     True,
     False,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -639,16 +639,12 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
     "menu_exit",
     "del_finalizer",
     ])
-@pytest.mark.parametrize('empty_scene', [
-    True,
-    False,
-    ])
-def test_background_plotting_close(qtbot, close_event, empty_scene, plotting):
+def test_background_plotting_close(qtbot, close_event, plotting):
     from pyvista.plotting.plotting import _ALL_PLOTTERS, close_all
     close_all()  # this is necessary to test _ALL_PLOTTERS
     assert len(_ALL_PLOTTERS) == 0
 
-    plotter = _create_testing_scene(empty_scene)
+    plotter = _create_testing_scene()
 
     # check that BackgroundPlotter.__init__() is called
     assert_hasattr(plotter, "app_window", MainWindow)
@@ -744,41 +740,34 @@ def test_multiplotter(qtbot, plotting):
     mp.close()
 
 
-def _create_testing_scene(empty_scene, show=False, off_screen=False):
-    if empty_scene:
-        plotter = BackgroundPlotter(
-            show=show,
-            off_screen=off_screen,
-            update_app_icon=False,
-        )
-    else:
-        plotter = BackgroundPlotter(
-            shape=(2, 2),
-            border=True,
-            border_width=10,
-            border_color='grey',
-            show=show,
-            off_screen=off_screen
-        )
-        plotter.set_background('black', top='blue')
-        plotter.subplot(0, 0)
-        cone = pyvista.Cone(resolution=4)
-        actor = plotter.add_mesh(cone)
-        plotter.remove_actor(actor)
-        plotter.add_text('Actor is removed')
-        plotter.subplot(0, 1)
-        plotter.add_mesh(pyvista.Box(), color='green', opacity=0.8)
-        plotter.subplot(1, 0)
-        cylinder = pyvista.Cylinder(resolution=6)
-        plotter.add_mesh(cylinder, smooth_shading=True)
-        plotter.show_bounds()
-        plotter.subplot(1, 1)
-        sphere = pyvista.Sphere(
-            phi_resolution=6,
-            theta_resolution=6
-        )
-        plotter.add_mesh(sphere)
-        plotter.enable_cell_picking()
+def _create_testing_scene(show=False, off_screen=False):
+    plotter = BackgroundPlotter(
+        shape=(2, 2),
+        border=True,
+        border_width=10,
+        border_color='grey',
+        show=show,
+        off_screen=off_screen
+    )
+    plotter.set_background('black', top='blue')
+    plotter.subplot(0, 0)
+    cone = pyvista.Cone(resolution=4)
+    actor = plotter.add_mesh(cone)
+    plotter.remove_actor(actor)
+    plotter.add_text('Actor is removed')
+    plotter.subplot(0, 1)
+    plotter.add_mesh(pyvista.Box(), color='green', opacity=0.8)
+    plotter.subplot(1, 0)
+    cylinder = pyvista.Cylinder(resolution=6)
+    plotter.add_mesh(cylinder, smooth_shading=True)
+    plotter.show_bounds()
+    plotter.subplot(1, 1)
+    sphere = pyvista.Sphere(
+        phi_resolution=6,
+        theta_resolution=6
+    )
+    plotter.add_mesh(sphere)
+    plotter.enable_cell_picking()
     return plotter
 
 


### PR DESCRIPTION
I am just doing a routine check of the CIs before the release. I noticed failures on `LinuxConda` and `Linux Python37` jobs. Hopefully, it is just something minor like adjusting timeouts etc.

<details>

```
2021-12-14T13:29:57.0447323Z =================================== FAILURES ===================================
2021-12-14T13:29:57.0448358Z ____________________ test_background_plotting_add_callback _____________________
2021-12-14T13:29:57.0449063Z 
2021-12-14T13:29:57.0449873Z qtbot = <pytestqt.qtbot.QtBot object at 0x7fdc342a91f0>
2021-12-14T13:29:57.0451088Z monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0x7fdc342a9880>
2021-12-14T13:29:57.0451952Z plotting = None
2021-12-14T13:29:57.0452429Z 
2021-12-14T13:29:57.0455482Z     def test_background_plotting_add_callback(qtbot, monkeypatch, plotting):
2021-12-14T13:29:57.0456299Z         class CallBack(object):
2021-12-14T13:29:57.0456782Z             def __init__(self, sphere):
2021-12-14T13:29:57.0457495Z                 self.sphere = sphere
2021-12-14T13:29:57.0457850Z     
2021-12-14T13:29:57.0458194Z             def __call__(self):
2021-12-14T13:29:57.0458591Z                 self.sphere.points *= 0.5
2021-12-14T13:29:57.0458929Z     
2021-12-14T13:29:57.0459246Z         update_count = [0]
2021-12-14T13:29:57.0459661Z         orig_update_app_icon = BackgroundPlotter.update_app_icon
2021-12-14T13:29:57.0460043Z     
2021-12-14T13:29:57.0460381Z         def update_app_icon(slf):
2021-12-14T13:29:57.0460776Z             update_count[0] = update_count[0] + 1
2021-12-14T13:29:57.0461195Z             return orig_update_app_icon(slf)
2021-12-14T13:29:57.0461537Z     
2021-12-14T13:29:57.0476893Z         monkeypatch.setattr(BackgroundPlotter, 'update_app_icon', update_app_icon)
2021-12-14T13:29:57.0477970Z         plotter = BackgroundPlotter(
2021-12-14T13:29:57.0478532Z             show=False,
2021-12-14T13:29:57.0479366Z             off_screen=False,
2021-12-14T13:29:57.0480181Z             title='Testing Window',
2021-12-14T13:29:57.0480924Z             update_app_icon=True,  # also does add_callback
2021-12-14T13:29:57.0482362Z         )
2021-12-14T13:29:57.0483846Z         assert plotter._last_update_time == -np.inf
2021-12-14T13:29:57.0484714Z         sphere = pyvista.Sphere()
2021-12-14T13:29:57.0485275Z         mycallback = CallBack(sphere)
2021-12-14T13:29:57.0485819Z         plotter.add_mesh(sphere)
2021-12-14T13:29:57.0486401Z         plotter.add_callback(mycallback, interval=200, count=3)
2021-12-14T13:29:57.0486986Z     
2021-12-14T13:29:57.0487506Z         # check that timers are set properly in add_callback()
2021-12-14T13:29:57.0488132Z         assert_hasattr(plotter, "app_window", MainWindow)
2021-12-14T13:29:57.0488861Z         assert_hasattr(plotter, "_callback_timer", QTimer)
2021-12-14T13:29:57.0489489Z         assert_hasattr(plotter, "counters", list)
2021-12-14T13:29:57.0490006Z     
2021-12-14T13:29:57.0490522Z         window = plotter.app_window  # MainWindow
2021-12-14T13:29:57.0491115Z         callback_timer = plotter._callback_timer  # QTimer
2021-12-14T13:29:57.0492261Z         counter = plotter.counters[-1]  # Counter
2021-12-14T13:29:57.0492851Z     
2021-12-14T13:29:57.0493360Z         # ensure that the window is showed
2021-12-14T13:29:57.0493911Z         assert not window.isVisible()
2021-12-14T13:29:57.0494476Z         with qtbot.wait_exposed(window):
2021-12-14T13:29:57.0495229Z             window.show()
2021-12-14T13:29:57.0495736Z         assert window.isVisible()
2021-12-14T13:29:57.0496311Z         assert update_count[0] in [0, 1]  # macOS sometimes updates (1)
2021-12-14T13:29:57.0497193Z         # don't check _last_update_time for non-inf-ness, won't be updated on Win
2021-12-14T13:29:57.0498159Z         plotter.update_app_icon()  # the timer doesn't call it right away, so do it
2021-12-14T13:29:57.0499032Z         assert update_count[0] in [1, 2]
2021-12-14T13:29:57.0499842Z         plotter.update_app_icon()  # should be a no-op
2021-12-14T13:29:57.0500475Z         assert update_count[0] in [2, 3]
2021-12-14T13:29:57.0501105Z         with pytest.raises(ValueError, match="ndarray with shape"):
2021-12-14T13:29:57.0501887Z             plotter.set_icon(0.)
2021-12-14T13:29:57.0502684Z         # Maybe someday manually setting "set_icon" should disable update_app_icon?
2021-12-14T13:29:57.0503351Z         # Strings also supported directly by QIcon
2021-12-14T13:29:57.0503975Z         plotter.set_icon(os.path.join(
2021-12-14T13:29:57.0504575Z             os.path.dirname(pyvistaqt.__file__), "data",
2021-12-14T13:29:57.0505324Z             "pyvista_logo_square.png"))
2021-12-14T13:29:57.0505815Z     
2021-12-14T13:29:57.0506343Z         # ensure that self.callback_timer send a signal
2021-12-14T13:29:57.0506997Z         callback_blocker = qtbot.wait_signals([callback_timer.timeout], timeout=300)
2021-12-14T13:29:57.0507813Z         callback_blocker.wait()
2021-12-14T13:29:57.0508540Z         # ensure that self.counters send a signal
2021-12-14T13:29:57.0509179Z         counter_blocker = qtbot.wait_signals([counter.signal_finished], timeout=700)
2021-12-14T13:29:57.0509803Z >       counter_blocker.wait()
2021-12-14T13:29:57.0510465Z E       pytestqt.exceptions.TimeoutError: Emitted signals: None. Missing: [signal_finished()]
```

</details>