### PR TITLE
update codecov action and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         name: 'Install pyvistaqt'
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: success()
         name: 'Upload coverage to CodeCov'
 
@@ -98,7 +98,7 @@ jobs:
         name: 'Install pyvistaqt'
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: success()
         name: 'Upload coverage to CodeCov'
 
@@ -146,6 +146,6 @@ jobs:
       - shell: bash -el {0}
         run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         if: success()
         name: 'Upload coverage to CodeCov'

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,6 @@
 import os
+from packaging.version import Version
 import platform
-from distutils.version import LooseVersion
 
 import numpy as np
 import pytest
@@ -253,7 +253,7 @@ def test_qt_interactor(qtbot, plotting):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
-    if LooseVersion(pyvista.__version__) < '0.27.0':
+    if Version(pyvista.__version__) < Version('0.27.0'):
         assert not hasattr(vtk_widget, "iren")
     assert vtk_widget._closed
 
@@ -719,8 +719,8 @@ def test_background_plotting_close(qtbot, close_event, empty_scene, plotting):
     assert not render_timer.isActive()
 
     # check that BasePlotter.close() is called
-    if LooseVersion(pyvista.__version__) < '0.27.0':
-        assert not hasattr(vtk_widget, "iren")
+    if Version(pyvista.__version__) < Version('0.27.0'):
+        assert not hasattr(window.vtk_widget, "iren")
     assert plotter._closed
 
     # check that BasePlotter.__init__() is called only once


### PR DESCRIPTION
#### Upgrade codecov/codecov-action
The `codecov/codecov-action@v1` action will be deprecated as of 1 Feb 2022. This PR upgrades the action to `v2`

> Due to the deprecation of the underlying bash uploader, the Codecov GitHub Action has released v2 which will use the new uploader. You can learn more about our deprecation plan and the new uploader on our blog.

See https://about.codecov.io/blog/introducing-codecovs-new-uploader/ for more details.

---
#### Add Dependabot
Maintenance of our GitHub actions can be simplified and partially automated by enabling dependabot for GitHub actions. This has been added in this PR.

---
#### Bonus
Looks like `distutils` has been deprecated:
```
        # check that BasePlotter.close() is called
>       if LooseVersion(pyvista.__version__) < '0.27.0':

tests/test_plotting.py:722: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'LooseVersion' object has no attribute 'vstring'") raised in repr()] LooseVersion object at 0x7f0f990b0d00>
vstring = '0.32.1'

    def __init__ (self, vstring=None):
>       warnings.warn(
            "distutils Version classes are deprecated. "
            "Use packaging.version instead.",
            DeprecationWarning,
            stacklevel=2,
        )
E       DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
```

This PR patches that.