### PR TITLE
Continuously update zoom level during pinch action

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -328,6 +328,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         if pinch:
             self.camera.Zoom(pinch.scaleFactor())
             event.accept()
+            self.update()
         return True
 
     def key_press_event(self, obj: Any, event: Any) -> None:

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -269,8 +269,6 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         else:
             self._setup_key_press()
 
-        self._auto_update_orig = auto_update
-
         # Make the render timer but only activate if using auto update
         self.render_timer = QTimer(parent=parent)
         if float(auto_update) > 0.0:  # Can be False as well
@@ -328,23 +326,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         """Handle gesture events."""
         pinch = event.gesture(QtCore.Qt.PinchGesture)
         if pinch:
-            state = pinch.state()
-            if state == 1:  # Pinching has started
-                # Update more frequently
-                self.render_timer.setInterval(
-                    min(
-                        1/30. * 1000.,  # 30 Hz
-                        int((self._auto_update_orig ** -1) * 1000.0)
-                    )
-                )
-            elif state == 2:  # Pinch in progress
-                self.camera.Zoom(pinch.scaleFactor())
-            else:  # Finished or aborted
-                # Reset update interval
-                self.render_timer.setInterval(
-                    int((self._auto_update_orig ** -1) * 1000.0)
-                )
-
+            self.camera.Zoom(pinch.scaleFactor())
             event.accept()
         return True
 


### PR DESCRIPTION
This is just a proof-of-concept @GuillaumeFavelier and I cooked up earlier today to make for a smoother pinch-zooming experience on macOS while keeping CPU utilization low.

We're refreshing at a higher frequency during the pinch action, and reset the update interval to the previous value as soon as the pinch action has ended.

We monitored CPU usage and indeed it returns to ~0 after the pinching is over.

cc @agramfort @larsoner, this makes for a **much** nicer experience with MNE `plot_alignment()` on the Mac.