### PR TITLE
WIP,MNT: update linters

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,16 +13,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - name: Python Code Quality and Lint
-      uses: ricardochaves/python-lint@v1.3.0
-      with:
-        python-root-list: pyvistaqt
-        use-pylint: true
-        extra-pylint-options: --disable=F0401
-        use-pycodestyle: true
-        use-flake8: true
-        use-black: true
-        use-mypy: true
-        use-isort: true
-        extra-pycodestyle-options: --ignore=E501,E203,W503
-        extra-flake8-options: --ignore=E501,E203,W503
+    - run: |
+        python -m pip install --upgrade pip wheel
+        pip install --upgrade black isort pylint pycodestyle mypy flake8
+      name: 'Install dependencies with pip'
+    - run: make srcstyle
+      name: 'Run checks'


### PR DESCRIPTION
This PR migrates the maintenance of python code linting to the project but at least it's up-to-date.

It's still work in progress. I know `make srcstyle` will not be enough.