### PR TITLE
ENH: Allow subclassing MainWindow

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -46,8 +46,7 @@ import platform
 import time
 import warnings
 from functools import wraps
-from typing import (Any, Callable, Dict, Generator, List, Optional, Tuple,
-                    Union, Type)
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, Type
 
 import numpy as np  # type: ignore
 import pyvista
@@ -587,7 +586,9 @@ class BackgroundPlotter(QtInteractor):
         self.off_screen = _setup_off_screen(off_screen)
         if app_window_class is None:
             app_window_class = MainWindow
-        self.app_window = app_window_class(title=kwargs.get("title", global_theme.title))
+        self.app_window = app_window_class(
+            title=kwargs.get("title", global_theme.title)
+        )
         self.frame = QFrame(parent=self.app_window)
         self.frame.setFrameStyle(QFrame.NoFrame)
         vlayout = QVBoxLayout()

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -46,7 +46,7 @@ import platform
 import time
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union, Type
+from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, Union
 
 import numpy as np  # type: ignore
 import pyvista

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -46,7 +46,8 @@ import platform
 import time
 import warnings
 from functools import wraps
-from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import (Any, Callable, Dict, Generator, List, Optional, Tuple,
+                    Union, Type)
 
 import numpy as np  # type: ignore
 import pyvista
@@ -507,6 +508,9 @@ class BackgroundPlotter(QtInteractor):
         being automatically ``Modified``.  If set to ``True``, update
         rate will be 1 second.
 
+    app_window_class : None, class, optional
+        A subclass of MainWindow to use when creating the app window.
+
     Examples
     --------
     >>> import pyvista as pv
@@ -534,6 +538,7 @@ class BackgroundPlotter(QtInteractor):
         menu_bar: bool = True,
         editor: bool = True,
         update_app_icon: Optional[bool] = None,
+        app_window_class: Optional[Type[MainWindow]] = None,
         **kwargs: Any,
     ) -> None:
         # pylint: disable=too-many-branches
@@ -580,8 +585,9 @@ class BackgroundPlotter(QtInteractor):
         self.ipython = _setup_ipython()
         self.app = _setup_application(app)
         self.off_screen = _setup_off_screen(off_screen)
-
-        self.app_window = MainWindow(title=kwargs.get("title", global_theme.title))
+        if app_window_class is None:
+            app_window_class = MainWindow
+        self.app_window = app_window_class(title=kwargs.get("title", global_theme.title))
         self.frame = QFrame(parent=self.app_window)
         self.frame.setFrameStyle(QFrame.NoFrame)
         vlayout = QVBoxLayout()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -80,13 +80,19 @@ def test_ipython(qapp):
     IPython.start_ipython(argv=["-c", cmd])
 
 
+class SuperWindow(MainWindow):
+    pass
+
+
 def test_depth_peeling(qtbot):
     plotter = BackgroundPlotter()
     qtbot.addWidget(plotter.app_window)
     assert not plotter.renderer.GetUseDepthPeeling()
     plotter.close()
     global_theme.depth_peeling["enabled"] = True
-    plotter = BackgroundPlotter()
+    plotter = BackgroundPlotter(app_window_class=SuperWindow)
+    assert isinstance(plotter.app_window, SuperWindow)
+    assert isinstance(plotter.app_window, MainWindow)
     qtbot.addWidget(plotter.app_window)
     assert plotter.renderer.GetUseDepthPeeling()
     plotter.close()


### PR DESCRIPTION
Over in MNE-Python we want to subclass the MainWindow that is instantiated by BackgroundPlotter to override event processing (https://github.com/mne-tools/mne-python/issues/9182#issuecomment-805737809) .This PR makes it possible to pass the class to use for instantiation.