### PR TITLE
FIX: AttributeError MouseMoveEvent on Qt6

### DIFF
--- a/pyvistaqt/rwi.py
+++ b/pyvistaqt/rwi.py
@@ -212,9 +212,9 @@ Key = Qt.Key if PyQtImpl == "PyQt6" else Qt
 
 
 def _get_event_pos(ev):
-    if PyQtImpl in ["PySide6", "PyQt6"]:
+    try:  # Qt6+
         return ev.position().x(), ev.position().y()
-    else:
+    except AttributeError:  # Qt5
         return ev.x(), ev.y()
 
 

--- a/pyvistaqt/rwi.py
+++ b/pyvistaqt/rwi.py
@@ -210,6 +210,14 @@ SizePolicy = QSizePolicy.Policy if PyQtImpl == "PyQt6" else QSizePolicy
 ConnectionType = Qt.ConnectionType if PyQtImpl == "PyQt6" else Qt
 Key = Qt.Key if PyQtImpl == "PyQt6" else Qt
 
+
+def _get_event_pos(ev):
+    if PyQtImpl in ["PySide6", "PyQt6"]:
+        return ev.position().x(), ev.position().y()
+    else:
+        return ev.x(), ev.y()
+
+
 class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
     """ A QVTKRenderWindowInteractor for Python and Qt.  Uses a
@@ -537,11 +545,12 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
         self._Iren.LeaveEvent()
 
     def mousePressEvent(self, ev):
+        pos_x, pos_y = _get_event_pos(ev)
         ctrl, shift = self._GetCtrlShift(ev)
         repeat = 0
         if ev.type() == QEvent.MouseButtonDblClick:
             repeat = 1
-        self._setEventInformation(ev.x(), ev.y(),
+        self._setEventInformation(pos_x, pos_y,
                                   ctrl, shift, chr(0), repeat, None)
 
         self._ActiveButton = ev.button()
@@ -554,8 +563,9 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
             self._Iren.MiddleButtonPressEvent()
 
     def mouseReleaseEvent(self, ev):
+        pos_x, pos_y = _get_event_pos(ev)
         ctrl, shift = self._GetCtrlShift(ev)
-        self._setEventInformation(ev.x(), ev.y(),
+        self._setEventInformation(pos_x, pos_y,
                                   ctrl, shift, chr(0), 0, None)
 
         if self._ActiveButton == Qt.LeftButton:
@@ -566,13 +576,14 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
             self._Iren.MiddleButtonReleaseEvent()
 
     def mouseMoveEvent(self, ev):
+        pos_x, pos_y = _get_event_pos(ev)
         self.__saveModifiers = ev.modifiers()
         self.__saveButtons = ev.buttons()
-        self.__saveX = ev.x()
-        self.__saveY = ev.y()
+        self.__saveX = pos_x
+        self.__saveY = pos_y
 
         ctrl, shift = self._GetCtrlShift(ev)
-        self._setEventInformation(ev.x(), ev.y(),
+        self._setEventInformation(pos_x, pos_y,
                                   ctrl, shift, chr(0), 0, None)
         self._Iren.MouseMoveEvent()
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,6 +7,7 @@ import pytest
 import pyvista
 import vtk
 from qtpy.QtWidgets import QAction, QFrame, QMenuBar, QToolBar, QVBoxLayout
+from qtpy import QtCore
 from qtpy.QtCore import Qt, QPoint, QMimeData, QUrl
 from qtpy.QtGui import QDragEnterEvent
 from qtpy.QtWidgets import (QTreeWidget, QStackedWidget, QCheckBox,
@@ -70,6 +71,18 @@ def test_check_type():
         _check_type(0, "foo", [str])
     _check_type(0, "foo", [int, float])
     _check_type("foo", "foo", [str])
+
+
+def test_mouse_interactions(qtbot):
+    from qtpy import QtCore
+    plotter = BackgroundPlotter()
+    window = plotter.app_window
+    interactor = plotter.interactor
+    qtbot.addWidget(window)
+    point = QPoint(0, 0)
+    qtbot.mouseMove(interactor, point)
+    qtbot.mouseClick(interactor, QtCore.Qt.LeftButton)
+    plotter.close()
 
 
 @pytest.mark.skipif(platform.system()=="Windows" and platform.python_version()[:-1]=="3.8.", reason="#51")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -74,7 +74,6 @@ def test_check_type():
 
 
 def test_mouse_interactions(qtbot):
-    from qtpy import QtCore
     plotter = BackgroundPlotter()
     window = plotter.app_window
     interactor = plotter.interactor


### PR DESCRIPTION
This PR fixes the issue with the position of the event on Qt6.

This also reveals one of the weaknesses of our testing since we do not simulate clicks. I could take the time to address this in here if I can.

Related to https://github.com/pyvista/pyvistaqt/issues/20#issuecomment-1064069790