### PR TITLE
MNT: bump pyvista version requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        pyvista: ['0.31', '0.32', '0.33']
+        pyvista: ['0.32', '0.33']
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -22,7 +22,6 @@ jobs:
     - run: |
         python -m pip install --upgrade pip wheel
         pip install -r requirements_test.txt
-        pip install --upgrade black isort pylint pycodestyle mypy flake8 codespell pydocstyle
       name: 'Install dependencies with pip'
     - run: make black
       name: 'Run black'

--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,5 @@ dependencies:
   - pip
   - pip:
       - vtk
-      - pyvista>=0.25.0
+      - pyvista>=0.32.0
       - pytest-memprof

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,6 +4,9 @@ disallow_untyped_defs = True
 [mypy-vtk.*]
 ignore_missing_imports = True
 
+[mypy-vtkmodules.*]
+ignore_missing_imports = True
+
 [mypy-pyvista.*]
 ignore_missing_imports = True
 

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -16,7 +16,6 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
 from vtkmodules.vtkRenderingCore import vtkActor
 
 from .window import MainWindow

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -17,10 +17,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-try:  # backwards compatibility with pyvista<0.29.0
-    from pyvista._vtk import vtkActor  # pylint: disable=ungrouped-imports
-except ImportError:  # pragma: no cover
-    from vtk import vtkActor
+from vtkmodules.vtkRenderingCore import vtkActor
 
 from .window import MainWindow
 

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -378,26 +378,25 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         exist.  User can drop anything in this window and we only want
         to allow files.
         """
-        # pragma: no cover
         try:
             for url in event.mimeData().urls():
                 if os.path.isfile(url.path()):
                     # only call accept on files
                     event.accept()
         except IOError as exception:  # pragma: no cover
-            warnings.warn(f"Exception when dropping files: {str(exception)}")
+            warnings.warn(f"Exception when dragging files: {str(exception)}")
 
     # pylint: disable=invalid-name,useless-return
     def dropEvent(self, event: QtCore.QEvent) -> None:
         """Event is called after dragEnterEvent."""
-        for url in event.mimeData().urls():  # pragma: no cover
-            self.url = url
-            filename = self.url.path()
-            if os.path.isfile(filename):
-                try:
+        try:
+            for url in event.mimeData().urls():
+                self.url = url
+                filename = self.url.path()
+                if os.path.isfile(filename):
                     self.add_mesh(pyvista.read(filename))
-                except IOError as exception:
-                    print(str(exception))
+        except IOError as exception:  # pragma: no cover
+            warnings.warn(f"Exception when dropping files: {str(exception)}")
 
     def close(self) -> None:
         """Quit application."""

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -68,7 +68,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from vtk import vtkGenericRenderWindowInteractor
+from vtkmodules.vtkRenderingUI import vtkGenericRenderWindowInteractor
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -51,7 +51,9 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, 
 import numpy as np  # type: ignore
 import pyvista
 import scooby  # type: ignore
+from pyvista import global_theme
 from pyvista.plotting.plotting import BasePlotter
+from pyvista.plotting.render_window_interactor import RenderWindowInteractor
 from pyvista.utilities import conditional_decorator, threaded
 from qtpy import QtCore
 from qtpy.QtCore import QSize, QTimer, Signal
@@ -66,9 +68,7 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-
 from vtk import vtkGenericRenderWindowInteractor
-from pyvista import global_theme
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog
@@ -82,7 +82,6 @@ from .utils import (
     _setup_off_screen,
 )
 from .window import MainWindow
-
 
 if scooby.in_ipython():  # pragma: no cover
     # pylint: disable=unused-import
@@ -275,11 +274,6 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         if off_screen:
             self.iren: Any = None
         else:
-            # pylint: disable=import-outside-toplevel
-            from pyvista.plotting.render_window_interactor import (
-                RenderWindowInteractor,
-            )
-
             self.iren = RenderWindowInteractor(
                 self, interactor=self.ren_win.GetInteractor()
             )

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -67,12 +67,8 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-try:  # backwards compatibility with pyvista<0.32.0
-    # pylint: disable=ungrouped-imports
-    from pyvista._vtk import vtkGenericRenderWindowInteractor
-except ImportError:  # pragma: no cover
-    # pylint: disable=ungrouped-imports
-    from vtk import vtkGenericRenderWindowInteractor
+from vtk import vtkGenericRenderWindowInteractor
+from pyvista import global_theme
 
 from .counter import Counter
 from .dialog import FileDialog, ScaleAxesDialog
@@ -87,21 +83,6 @@ from .utils import (
 )
 from .window import MainWindow
 
-try:
-    from pyvista import global_theme  # pylint: disable=ungrouped-imports
-except ImportError:  # workaround for older PyVista
-    from pyvista import rcParams  # pylint: disable=ungrouped-imports
-
-    class _GlobalTheme:
-        """Wrap global_theme too rcParams."""
-
-        def __setattr__(self, k: str, val: Any) -> None:  # noqa: D105
-            rcParams[k] = val
-
-        def __getattr__(self, k: str) -> None:  # noqa: D105
-            return rcParams[k] if k != "__wrapped__" else None
-
-    global_theme = _GlobalTheme()  # pylint: disable=invalid-name
 
 if scooby.in_ipython():  # pragma: no cover
     # pylint: disable=unused-import
@@ -294,33 +275,25 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         if off_screen:
             self.iren: Any = None
         else:
-            try:
-                # pylint: disable=import-outside-toplevel
-                from pyvista.plotting.render_window_interactor import (
-                    RenderWindowInteractor,
-                )
+            # pylint: disable=import-outside-toplevel
+            from pyvista.plotting.render_window_interactor import (
+                RenderWindowInteractor,
+            )
 
-                self.iren = RenderWindowInteractor(
-                    self, interactor=self.ren_win.GetInteractor()
-                )
-                self.iren.interactor.RemoveObservers(
-                    "MouseMoveEvent"
-                )  # slows window update?
-                self.iren.initialize()
-            except ImportError:
-                self.iren = self.ren_win.GetInteractor()
-                self.iren.RemoveObservers("MouseMoveEvent")  # slows window update?
-                self.iren.Initialize()
+            self.iren = RenderWindowInteractor(
+                self, interactor=self.ren_win.GetInteractor()
+            )
+            self.iren.interactor.RemoveObservers(
+                "MouseMoveEvent"
+            )  # slows window update?
+            self.iren.initialize()
             self.enable_trackball_style()
 
     def _setup_key_press(self) -> None:
-        try:
-            self._observers: Dict[
-                None, None
-            ] = {}  # Map of events to observers of self.iren
-            self.iren.add_observer("KeyPressEvent", self.key_press_event)
-        except AttributeError:
-            self._add_observer("KeyPressEvent", self.key_press_event)
+        self._observers: Dict[
+            None, None
+        ] = {}  # Map of events to observers of self.iren
+        self.iren.add_observer("KeyPressEvent", self.key_press_event)
         self.reset_key_events()
 
     def gesture_event(self, event: QGestureEvent) -> bool:

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,7 +5,7 @@ pytest
 pytest-cov
 pytest-memprof
 pytest-qt
-pyvista>=0.25.0
+pyvista>=0.32.0
 qtpy>=1.9.0
 scooby>=0.5.1
 vtk

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,3 +9,11 @@ pyvista>=0.25.0
 qtpy>=1.9.0
 scooby>=0.5.1
 vtk
+black
+isort
+pylint
+pycodestyle
+mypy
+flake8
+codespell
+pydocstyle

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords='vtk numpy plotting mesh qt',
     python_requires='>=3.6.*',
     install_requires=[
-        'pyvista>=0.25.0',
+        'pyvista>=0.32.0',
         'QtPy>=1.9.0',
     ],
     package_data={'pyvistaqt': [

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -8,7 +8,7 @@ import pyvista
 import vtk
 from qtpy.QtWidgets import QAction, QFrame, QMenuBar, QToolBar, QVBoxLayout
 from qtpy import QtCore
-from qtpy.QtCore import Qt, QPoint, QMimeData, QUrl
+from qtpy.QtCore import Qt, QPoint, QPointF, QMimeData, QUrl
 from qtpy.QtGui import QDragEnterEvent, QDropEvent
 from qtpy.QtWidgets import (QTreeWidget, QStackedWidget, QCheckBox,
                             QGestureEvent, QPinchGesture)
@@ -633,7 +633,7 @@ def test_drop_event(tmpdir):
     mesh.save(filename)
     assert os.path.isfile(filename)
     plotter = BackgroundPlotter()
-    point = QPoint(0, 0)
+    point = QPointF(0, 0)
     data = QMimeData()
     data.setUrls([QUrl(filename)])
     event = QDropEvent(

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -9,7 +9,7 @@ import vtk
 from qtpy.QtWidgets import QAction, QFrame, QMenuBar, QToolBar, QVBoxLayout
 from qtpy import QtCore
 from qtpy.QtCore import Qt, QPoint, QMimeData, QUrl
-from qtpy.QtGui import QDragEnterEvent
+from qtpy.QtGui import QDragEnterEvent, QDropEvent
 from qtpy.QtWidgets import (QTreeWidget, QStackedWidget, QCheckBox,
                             QGestureEvent, QPinchGesture)
 from pyvistaqt.plotting import global_theme
@@ -624,6 +624,27 @@ def test_background_plotting_menu_bar(qtbot, plotting):
     plotter.close()
     assert not main_menu.isVisible()
     assert plotter._last_update_time == -np.inf
+
+
+def test_drop_event(tmpdir):
+    output_dir = str(tmpdir.mkdir("tmpdir"))
+    filename = str(os.path.join(output_dir, "tmp.vtk"))
+    mesh = pyvista.Cone()
+    mesh.save(filename)
+    assert os.path.isfile(filename)
+    plotter = BackgroundPlotter()
+    point = QPoint(0, 0)
+    data = QMimeData()
+    data.setUrls([QUrl(filename)])
+    event = QDropEvent(
+        point,
+        Qt.DropAction.IgnoreAction,
+        data,
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+    )
+    plotter.dropEvent(event)
+    plotter.close()
 
 
 def test_drag_event(tmpdir):


### PR DESCRIPTION
This PR bumps the required version of `pyvista` to `0.32` and effectively removes obsolete or untested code.