### PR TITLE
MNT: conda forge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt: ['PySide2', 'PySide6', 'PyQt5', 'PyQt6']
+        qt: ['None', 'PySide2', 'PySide6', 'PyQt5', 'PyQt6']
     defaults:
       run:
         shell: bash
@@ -40,6 +40,7 @@ jobs:
         name: 'Install dependencies with pip'
       - run: pip install ${{ matrix.qt }}
         name: 'Install Qt binding'
+        if: matrix.qt != 'None'
       - run: |
           pip install -e .
           python -c "import pyvista; print(pyvista.Report())"
@@ -48,6 +49,10 @@ jobs:
         name: 'Run QVTKRenderWidgetConeExample'
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
+        if: matrix.qt != 'None'
+      - run: python -c "import pyvistaqt; print(pyvistaqt.__version__)"
+        name: 'Import without Qt'
+        if: matrix.qt == 'None'
       - uses: codecov/codecov-action@v2
         if: success()
         name: 'Upload coverage to CodeCov'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         name: 'Run Tests'
         if: matrix.qt != 'None'
       - run: |
-          pip uninstall pytest-qt
+          pip uninstall -y pytest-qt
           pytest -v tests/test_qt.py
         name: 'Import without Qt'
         if: matrix.qt == 'None'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
         if: matrix.qt != 'None'
-      - run: pytest -v tests/test_qt.py
+      - run: |
+          pip uninstall pytest-qt
+          pytest -v tests/test_qt.py
         name: 'Import without Qt'
         if: matrix.qt == 'None'
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
         if: matrix.qt != 'None'
-      - run: python -c "import pyvistaqt; print(pyvistaqt.__version__)"
+      - run: pytest -v tests/test_qt.py
         name: 'Import without Qt'
         if: matrix.qt == 'None'
       - uses: codecov/codecov-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         name: 'Install pyvistaqt'
       - run: python pyvistaqt/rwi.py
         name: 'Run QVTKRenderWidgetConeExample'
+        if: matrix.qt != 'None'
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: 'Run Tests'
         if: matrix.qt != 'None'

--- a/mypy_checklist.txt
+++ b/mypy_checklist.txt
@@ -1,4 +1,3 @@
-pyvistaqt/__init__.py
 pyvistaqt/_version.py
 pyvistaqt/counter.py
 pyvistaqt/dialog.py

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -4,11 +4,12 @@ from ._version import __version__
 try:
     from qtpy import QtCore  # noqa
 except ModuleNotFoundError as exc:  # pragma: no cover
+    _exc_msg = exc
 
     # pylint: disable=too-few-public-methods
     class _QtBindingError:
         def __init__(self, *args, **kwargs):
-            raise RuntimeError(f"No Qt binding was found, got: {exc}")
+            raise RuntimeError(f"No Qt binding was found, got: {_exc_msg}")
 
     # pylint: disable=too-few-public-methods
     class BackgroundPlotter(_QtBindingError):

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -3,7 +3,7 @@ from ._version import __version__
 
 try:
     from qtpy import QtCore  # noqa
-except Exception as exc:  # pragma: no cover
+except Exception as exc:  # pragma: no cover # pylint: disable=broad-except
     _exc_msg = exc
 
     # pylint: disable=too-few-public-methods

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -3,7 +3,7 @@ from ._version import __version__
 
 try:
     from qtpy import QtCore  # noqa
-except ModuleNotFoundError:
+except ModuleNotFoundError:  # pragma: no cover
 
     # pylint: disable=too-few-public-methods
     class _QtBindingError:

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -1,6 +1,28 @@
 """PyVista package for 3D plotting and mesh analysis."""
-from pyvistaqt._version import __version__
-from pyvistaqt.plotting import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
+from ._version import __version__
+
+
+try:
+    from qtpy import QtCore  # noqa
+except ModuleNotFoundError:
+    class BackgroundPlotter:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError('No Qt binding found')
+
+    class MainWindow:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError('No Qt binding found')
+
+    class MultiPlotter:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError('No Qt binding found')
+
+    class QtInteractor:
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError('No Qt binding found')
+else:
+    from .plotting import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
+
 
 __all__ = [
     "__version__",

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -5,26 +5,26 @@ try:
     from qtpy import QtCore  # noqa
 except ModuleNotFoundError:
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
+    # pylint: disable=too-few-public-methods
     class _QtBindingError:
         def __init__(self, *args, **kwargs):
             raise RuntimeError("No Qt binding is found")
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
+    # pylint: disable=too-few-public-methods
     class BackgroundPlotter(_QtBindingError):
-        pass
+        """Handle Qt binding error for BackgroundPlotter."""
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
+    # pylint: disable=too-few-public-methods
     class MainWindow(_QtBindingError):
-        pass
+        """Handle Qt binding error for MainWindow."""
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
+    # pylint: disable=too-few-public-methods
     class MultiPlotter(_QtBindingError):
-        pass
+        """Handle Qt binding error for MultiPlotter."""
 
-    # pylint: disable=too-few-public-methods,missing-class-docstring
+    # pylint: disable=too-few-public-methods
     class QtInteractor(_QtBindingError):
-        pass
+        """Handle Qt binding error for QtInteractor."""
 
 else:
     from .plotting import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -3,12 +3,12 @@ from ._version import __version__
 
 try:
     from qtpy import QtCore  # noqa
-except ModuleNotFoundError:  # pragma: no cover
+except ModuleNotFoundError as exc:  # pragma: no cover
 
     # pylint: disable=too-few-public-methods
     class _QtBindingError:
         def __init__(self, *args, **kwargs):
-            raise RuntimeError("No Qt binding is found")
+            raise RuntimeError(f"No Qt binding was found, got: {exc}")
 
     # pylint: disable=too-few-public-methods
     class BackgroundPlotter(_QtBindingError):

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -1,25 +1,31 @@
 """PyVista package for 3D plotting and mesh analysis."""
 from ._version import __version__
 
-
 try:
     from qtpy import QtCore  # noqa
 except ModuleNotFoundError:
+
+    # pylint: disable=too-few-public-methods,missing-class-docstring
     class _QtBindingError:
         def __init__(self, *args, **kwargs):
-            raise RuntimeError('No Qt binding is found')
+            raise RuntimeError("No Qt binding is found")
 
+    # pylint: disable=too-few-public-methods,missing-class-docstring
     class BackgroundPlotter(_QtBindingError):
         pass
 
+    # pylint: disable=too-few-public-methods,missing-class-docstring
     class MainWindow(_QtBindingError):
         pass
 
+    # pylint: disable=too-few-public-methods,missing-class-docstring
     class MultiPlotter(_QtBindingError):
         pass
 
+    # pylint: disable=too-few-public-methods,missing-class-docstring
     class QtInteractor(_QtBindingError):
         pass
+
 else:
     from .plotting import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
 

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -3,7 +3,7 @@ from ._version import __version__
 
 try:
     from qtpy import QtCore  # noqa
-except ModuleNotFoundError as exc:  # pragma: no cover
+except Exception as exc:  # pragma: no cover
     _exc_msg = exc
 
     # pylint: disable=too-few-public-methods

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -5,21 +5,21 @@ from ._version import __version__
 try:
     from qtpy import QtCore  # noqa
 except ModuleNotFoundError:
-    class BackgroundPlotter:
+    class _QtBindingError:
         def __init__(self, *args, **kwargs):
-            raise RuntimeError('No Qt binding found')
+            raise RuntimeError('No Qt binding is found')
 
-    class MainWindow:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError('No Qt binding found')
+    class BackgroundPlotter(_QtBindingError):
+        pass
 
-    class MultiPlotter:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError('No Qt binding found')
+    class MainWindow(_QtBindingError):
+        pass
 
-    class QtInteractor:
-        def __init__(self, *args, **kwargs):
-            raise RuntimeError('No Qt binding found')
+    class MultiPlotter(_QtBindingError):
+        pass
+
+    class QtInteractor(_QtBindingError):
+        pass
 else:
     from .plotting import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
 

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -40,10 +40,6 @@ We fix this by internally by temporarily monkey-patching
 ``BasePlotter.__init__`` with a no-op ``__init__``.
 """
 
-from . import QT_BINDING_ERROR
-
-if QT_BINDING_ERROR:
-    raise RuntimeError("Qt issue")
 
 import contextlib
 import logging

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -39,6 +39,12 @@ probably entirely separate from the Python ``super()`` process.
 We fix this by internally by temporarily monkey-patching
 ``BasePlotter.__init__`` with a no-op ``__init__``.
 """
+
+from . import QT_BINDING_ERROR
+
+if QT_BINDING_ERROR:
+    raise RuntimeError("Qt issue")
+
 import contextlib
 import logging
 import os

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -39,8 +39,6 @@ probably entirely separate from the Python ``super()`` process.
 We fix this by internally by temporarily monkey-patching
 ``BasePlotter.__init__`` with a no-op ``__init__``.
 """
-
-
 import contextlib
 import logging
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import pytest
+import importlib
+import qtpy
 from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
@@ -26,4 +28,5 @@ def no_qt(monkeypatch):
     """Require plotting."""
     if _check_qt_installed():
         monkeypatch.setenv('QT_API', 'bad_name')
+        importlib.reload(qtpy)
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ NO_PLOTTING = not system_supports_plotting()
 def _check_qt_installed():
     try:
         from qtpy import QtCore  # noqa
-    except ModuleNotFoundError:
+    except Exception:
         return False
     else:
         return True
@@ -22,8 +22,8 @@ def plotting():
 
 
 @pytest.fixture()
-def no_qt():
+def no_qt(monkeypatch):
     """Require plotting."""
     if _check_qt_installed():
-        pytest.skip(reason="Requires that Qt is not installed")
+        monkeypatch.setenv('QT_API', 'bad_name')
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,29 @@
-import gc
-import os
 import pytest
-import pyvista
 from pyvista.plotting import system_supports_plotting
 
 NO_PLOTTING = not system_supports_plotting()
+
+
+def _check_qt_installed():
+    try:
+        from qtpy import QtCore  # noqa
+    except ModuleNotFoundError:
+        return False
+    else:
+        return True
+
 
 @pytest.fixture()
 def plotting():
     """Require plotting."""
     if NO_PLOTTING:
         pytest.skip(NO_PLOTTING, reason="Requires system to support plotting")
+    yield
+
+
+@pytest.fixture()
+def no_qt():
+    """Require plotting."""
+    if _check_qt_installed():
+        pytest.skip(reason="Requires that Qt is not installed")
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,5 +28,8 @@ def no_qt(monkeypatch):
     """Require plotting."""
     if _check_qt_installed():
         monkeypatch.setenv('QT_API', 'bad_name')
-        importlib.reload(qtpy)
+        try:
+            importlib.reload(qtpy)
+        except Exception:
+            pass
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
-import pytest
 import importlib
-import qtpy
+import sys
+
+import pytest
 from pyvista.plotting import system_supports_plotting
+import pyvistaqt
 
 NO_PLOTTING = not system_supports_plotting()
 
@@ -26,10 +28,15 @@ def plotting():
 @pytest.fixture()
 def no_qt(monkeypatch):
     """Require plotting."""
+    need_reload = False
     if _check_qt_installed():
+        need_reload = True
         monkeypatch.setenv('QT_API', 'bad_name')
-        try:
-            importlib.reload(qtpy)
-        except Exception:
-            pass
+        sys.modules.pop('qtpy')
+        importlib.reload(pyvistaqt)
+        assert 'qtpy' not in sys.modules
     yield
+    monkeypatch.undo()
+    if need_reload:
+        importlib.reload(pyvistaqt)
+        assert 'qtpy' in sys.modules

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -1,9 +1,8 @@
 import pytest
 
-from pyvistaqt import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
-
 
 def test_no_qt_binding(no_qt):
+    from pyvistaqt import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
     with pytest.raises(RuntimeError, match="No Qt binding"):
         BackgroundPlotter()
     with pytest.raises(RuntimeError, match="No Qt binding"):

--- a/tests/test_qt.py
+++ b/tests/test_qt.py
@@ -1,0 +1,14 @@
+import pytest
+
+from pyvistaqt import BackgroundPlotter, MainWindow, MultiPlotter, QtInteractor
+
+
+def test_no_qt_binding(no_qt):
+    with pytest.raises(RuntimeError, match="No Qt binding"):
+        BackgroundPlotter()
+    with pytest.raises(RuntimeError, match="No Qt binding"):
+        MainWindow()
+    with pytest.raises(RuntimeError, match="No Qt binding"):
+        MultiPlotter()
+    with pytest.raises(RuntimeError, match="No Qt binding"):
+        QtInteractor()


### PR DESCRIPTION
`pyqt` **should not** be in the recipe of `conda-forge/pyvistaqt-feedstock` since `pyvistaqt` does not install *any* Qt API.

The goal of the PR is to help with this issue:

https://github.com/conda-forge/pyvistaqt-feedstock/pull/9#issuecomment-996413063