### PR TITLE
MNT: CIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        pyvista: ['0.32', '0.33']
+        pyvista: ['0.32', '0.33', '0.34']
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Now that `pyvista 0.34.0` is released, this PR adds a new target to the testing matrix.