### PR TITLE
Update Formatting Tools

### DIFF
--- a/.ci/azure-pipelines.yml
+++ b/.ci/azure-pipelines.yml
@@ -52,7 +52,7 @@ stages:
       inputs:
         versionSpec: '3.7'
     - script: |
-        pip install codespell pydocstyle
+        pip install codespell pydocstyle[toml]
         make doctest
       displayName: 'Run doctest'
 

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = *.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*
+ignore-words-list = lod,byteorder,flem,parm,doubleclick,revered,PullRequest
+quiet-level = 3

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 [codespell]
-skip = *.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.vtu,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,doc/_build/*,./doc/images/*,./dist/*,*~,.hypothesis*,./doc/examples/*,*.mypy_cache/*,*cover,./tests/tinypages/_build/*,*/_autosummary/*
+skip = ./.ci/*,./.git/*,./.hypothesis/*,./dist/*,./doc/examples/*,./doc/images/*,./docs/_build/*,./docs/images/*,./tests/tinypages/_build/*,.hypothesis*,*.doctree,*.eot,*.gif,*.html,*.inv,*.ipynb,*.jpg,*.js,*.json,*.mp4,*.mypy_cache/*,*.pickle,*.ply,*.png,*.pyc,*.ttf,*.txt,*.vti,*.vtk,*.vtu,*.woff,*.woff2,*.yml,*/_autosummary/*,*~,*cover,doc/_build/*,flycheck*
 ignore-words-list = lod,byteorder,flem,parm,doubleclick,revered,PullRequest
 quiet-level = 3

--- a/.flake8
+++ b/.flake8
@@ -16,7 +16,10 @@ exclude =
     pyvistaqt/rwi.py,
     # Only lint source files
     tests/*.py,
-    docs/*.py
+    docs/*.py,
+    # Ignore errors here in this commit (fix in future PR)
+    pyvistaqt/*.py,
+    setup.py
 max-complexity = 10
 doctests = true
 extend-ignore =

--- a/.flake8
+++ b/.flake8
@@ -14,6 +14,9 @@ exclude =
     dist,
     # This is adopted from VTK
     pyvistaqt/rwi.py,
+    # Only lint source files
+    tests/*.py,
+    docs/*.py
 max-complexity = 10
 doctests = true
 extend-ignore =

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,36 @@
+[flake8]
+max-line-length = 88
+exclude =
+    __pycache__,
+    .venv,
+    .cache,
+    .eggs
+    .git,
+    .tox,
+    *.egg-info,
+    *.pyc,
+    *.pyi,
+    build,
+    dist,
+    # This is adopted from VTK
+    pyvistaqt/rwi.py,
+max-complexity = 10
+doctests = true
+extend-ignore =
+    # whitespace before ':'
+    E203,
+    # line break before binary operator
+    W503,
+    # line length too long
+    E501,
+    # do not assign a lambda expression, use a def
+    E731,
+    # missing class docstring; use ``__init__`` docstring instead
+    D101,
+    # missing docstring in magic method
+    D105,
+    # Qt uses camelCase
+    N802
+per-file-ignores =
+    # Allow re-export of modules at package level
+    __init__.py:F401

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,4 +6,11 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 ensure_newline_before_comments=True
-extend_skip_glob=tests/*.py,docs/*.py,setup.py
+extend_skip_glob=tests/*.py,docs/conf.py,setup.py,pyvistaqt/rwi.py
+# `pre-comment` doesn't see skips; `filter_files=True` forces it
+# to see these files
+#
+# See:
+#   - https://jugmac00.github.io/blog/isort-and-pre-commit-a-friendship-with-obstacles/
+#   - https://github.com/PyCQA/isort/issues/885
+filter_files=True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,8 @@
 [settings]
+profile=black
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+ensure_newline_before_comments=True

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -6,3 +6,4 @@ force_grid_wrap=0
 use_parentheses=True
 line_length=88
 ensure_newline_before_comments=True
+extend_skip_glob=tests/*.py,docs/*.py,setup.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,29 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
+    args: [
+      "--config=pyproject.toml"
+    ]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.10.1
   hooks:
   - id: isort
+    args: [
+      "--check",
+      "--settings=.isort.cfg"
+    ]
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.961
+  hooks:
+    - id: mypy
+      args: [
+        "--config-file",
+        "mypy.ini",
+        "@mypy_checklist.txt"
+      ]
+
 
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 3.9.2
@@ -18,13 +36,16 @@ repos:
       "flake8-isort==4.1.1",
       "flake8-quotes==3.3.1",
     ]
+    args: [
+      "--config=.flake8"
+    ]
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
   hooks:
   - id: codespell
     args: [
-      "doc examples examples_flask pyvista tests",
+      "docs examples examples_flask pyvista tests",
       "*.py *.rst *.md",
     ]
 
@@ -33,8 +54,6 @@ repos:
   hooks:
   - id: pydocstyle
     additional_dependencies: [toml==0.10.2]
-    files: ^(pyvista/|other/)
-    exclude: ^pyvista/ext/
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0
@@ -59,8 +78,16 @@ repos:
       types: [python]
       args:
         [
-          "./pyvistaqt/",  # Files to lint
-          "--rcfile=.pylintrc", # Specify rc file
           "-rn", # Only display messages
           "-sn", # Don't display the score
+          "--rcfile=.pylintrc", # Specify rc file
+        ]
+    - id: pycodestyle
+      name: pycodestyle
+      entry: pycodestyle
+      language: system
+      types: [python]
+      args:
+        [
+          "--config=./\\.pycodestyle",
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,8 @@ repos:
       types: [python]
       args:
         [
+          "./pyvistaqt/",  # Files to lint
+          "--rcfile=.pylintrc", # Specify rc file
           "-rn", # Only display messages
           "-sn", # Don't display the score
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,64 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 22.3.0
+  hooks:
+  - id: black
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+
+- repo: https://gitlab.com/PyCQA/flake8
+  rev: 3.9.2
+  hooks:
+  - id: flake8
+    additional_dependencies: [
+      "flake8-black==0.3.2",
+      "flake8-isort==4.1.1",
+      "flake8-quotes==3.3.1",
+    ]
+
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.1.0
+  hooks:
+  - id: codespell
+    args: [
+      "doc examples examples_flask pyvista tests",
+      "*.py *.rst *.md",
+    ]
+
+- repo: https://github.com/pycqa/pydocstyle
+  rev: 6.1.1
+  hooks:
+  - id: pydocstyle
+    additional_dependencies: [toml==0.10.2]
+    files: ^(pyvista/|other/)
+    exclude: ^pyvista/ext/
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: check-merge-conflict
+  - id: debug-statements
+  - id: no-commit-to-branch
+    args: [--branch, main]
+
+# this validates our github workflow files
+- repo: https://github.com/python-jsonschema/check-jsonschema
+  rev: 0.16.1
+  hooks:
+    - id: check-github-workflows
+
+- repo: local
+  hooks:
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      args:
+        [
+          "-rn", # Only display messages
+          "-sn", # Don't display the score
+        ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,12 +20,21 @@ repos:
   rev: v0.961
   hooks:
     - id: mypy
+      # `pass_filenames` is used to overcome the "duplicate module"
+      # error from occuring. We are explicitly passing a 'txt'
+      # file to search. This setting tells `pre-commit` to not do a
+      # search and pass files to check to mypy, like it normally does.
+      #
+      # See:
+      #   - https://github.com/python/mypy/issues/4008#issuecomment-708060733
+      #   - https://pre-commit.com/#hooks-pass_filenames
+      language: system
+      pass_filenames: false
       args: [
         "--config-file",
         "mypy.ini",
         "@mypy_checklist.txt"
       ]
-
 
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 3.9.2
@@ -54,6 +63,12 @@ repos:
   hooks:
   - id: pydocstyle
     additional_dependencies: [toml==0.10.2]
+    # We use the 'match' and do not want pre-commit to pass
+    # globbed files
+    pass_filenames: false
+    args: [
+      "--config=pyproject.toml",
+    ]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0

--- a/.pycodestyle
+++ b/.pycodestyle
@@ -1,0 +1,8 @@
+[pycodestyle]
+ignore = E501,
+         E203,
+         W503
+exclude = tests/*.py,
+          docs/*.py,
+          rwi.py
+filename = pyvistaqt/*.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,7 @@ ignore=rwi.py,
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=(?!(coverage|test_|rwi)).*[.]py
+ignore-patterns=(?=(coverage|test_|rwi)).*[.]py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,8 @@ fail-under=10
 # paths.
 ignore=rwi.py,
        conf.py,
-       conftest.py
+       conftest.py,
+       setup.py  # ignore and fix in future PR
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,18 +3,24 @@
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=vtk
+extension-pkg-whitelist=vtk,
+                        PyQt5,
+                        PySide2,
+                        PyQt6,
+                        PySide6
 
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=10
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=rwi.py,
+       conf.py,
+       conftest.py
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=(?!(coverage|test_|rwi)).*[.]py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
@@ -60,17 +66,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
@@ -78,71 +74,13 @@ disable=print-statement,
         useless-suppression,
         deprecated-pragma,
         use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape,
-        bad-continuation,
         arguments-differ,
         no-name-in-module,
-        no-member
+        no-member,
+        # Redundant alias imports required for type hinting by PEP 484
+        useless-import-alias,
+        # Qt uses PascalCase
+        invalid-name,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,19 @@ PYLINT_DIRS ?= ./pyvistaqt/
 MYPY_DIRS ?= "mypy_checklist.txt"
 FLAKE8_DIRS ?= ./pyvistaqt/
 CODESPELL_DIRS ?= ./
-CODESPELL_SKIP ?= "*.json,*.pyc,*.txt,*.gif,*.png,*.jpg,*.ply,*.vtk,*.vti,*.js,*.html,*.doctree,*.ttf,*.woff,*.woff2,*.eot,*.mp4,*.inv,*.pickle,*.ipynb,flycheck*,./.git/*,./.hypothesis/*,*.yml,./docs/_build/*,./docs/images/*,./dist/*,./.ci/*"
-CODESPELL_IGNORE ?= "ignore_words.txt"
+PYDOCSTYLE_DIRS ?= ./pyvistaqt/
+COVERAGE_DIRS ?= ./pyvistaqt/
+COVERAGE_HTML_DIRS ?= ./pyvistaqt/
+COVERAGE_XML_DIRS ?= ./pyvistaqt/
 
-EXTRA_BLACK_OPTIONS ?= --exclude rwi.py
-EXTRA_ISORT_OPTIONS ?= --skip=rwi.py
-EXTRA_PYLINT_OPTIONS ?= --ignore=rwi.py
-EXTRA_PYCODESTYLE_OPTIONS ?= --ignore="E501,E203,W503" --exclude=rwi.py
-EXTRA_MYPY_OPTIONS ?= --follow-imports=skip
-EXTRA_FLAKE8_OPTIONS ?= --ignore="E501,E203,W503" --exclude=rwi.py
-EXTRA_PYDOCSTYLE_OPTIONS = --match='(?!(coverage|test_|rwi)).*\.py'
+EXTRA_CODESPELL_OPTIONS ?= --config .codespellrc
+EXTRA_BLACK_OPTIONS ?= --config pyproject.toml
+EXTRA_ISORT_OPTIONS ?= --check --settings=.isort.cfg
+EXTRA_PYLINT_OPTIONS ?= -rn -sn --rcfile=.pylintrc
+EXTRA_PYCODESTYLE_OPTIONS ?= --config=.pycodestyle
+EXTRA_MYPY_OPTIONS ?= --config-file mypy.ini
+EXTRA_FLAKE8_OPTIONS ?= --config=.flake8
+EXTRA_PYDOCSTYLE_OPTIONS = --config=pyproject.toml
 
 all: srcstyle doctest
 
@@ -26,15 +29,15 @@ doctest: codespell pydocstyle
 
 black:
 	@echo "Running black"
-	@black --check $(BLACK_DIRS) $(EXTRA_BLACK_OPTIONS)
+	@black $(BLACK_DIRS) $(EXTRA_BLACK_OPTIONS)
 
 isort:
 	@echo "Running isort"
-	@isort --check $(ISORT_DIRS) $(EXTRA_ISORT_OPTIONS)
+	@isort $(ISORT_DIRS) $(EXTRA_ISORT_OPTIONS)
 
 pylint:
 	@echo "Running pylint"
-	@pylint $(PYLINT_DIRS) --rcfile=.pylintrc $(EXTRA_PYLINT_OPTIONS)
+	@pylint $(PYLINT_DIRS) $(EXTRA_PYLINT_OPTIONS)
 
 pycodestyle:
 	@echo "Running pycodestyle"
@@ -42,7 +45,7 @@ pycodestyle:
 
 mypy:
 	@echo "Running mypy"
-	@mypy --config-file mypy.ini @$(MYPY_DIRS) $(EXTRA_MYPY_OPTIONS)
+	@mypy @$(MYPY_DIRS) $(EXTRA_MYPY_OPTIONS)
 
 flake8:
 	@echo "Running flake8"
@@ -50,20 +53,20 @@ flake8:
 
 codespell:
 	@echo "Running codespell"
-	@codespell $(CODESPELL_DIRS) -S $(CODESPELL_SKIP) -I $(CODESPELL_IGNORE)
+	@codespell $(CODESPELL_DIRS) $(EXTRA_CODESPELL_OPTIONS)
 
 pydocstyle:
 	@echo "Running pydocstyle"
-	@pydocstyle pyvistaqt $(EXTRA_PYDOCSTYLE_OPTIONS)
+	@pydocstyle $(PYDOCSTYLE_DIRS) $(EXTRA_PYDOCSTYLE_OPTIONS)
 
 coverage:
 	@echo "Running coverage"
-	@pytest -v --cov pyvistaqt
+	@pytest -v --cov $(COVERAGE_DIRS)
 
 coverage-xml:
 	@echo "Reporting XML coverage"
-	@pytest -v --cov pyvistaqt --cov-report xml
+	@pytest -v --cov $(COVERAGE_XML_DIRS) --cov-report xml
 
 coverage-html:
 	@echo "Reporting HTML coverage"
-	@pytest -v --cov pyvistaqt --cov-report html
+	@pytest -v --cov $(COVERAGE_HTML_DIRS) --cov-report html

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EXTRA_PYLINT_OPTIONS ?= --ignore=rwi.py
 EXTRA_PYCODESTYLE_OPTIONS ?= --ignore="E501,E203,W503" --exclude=rwi.py
 EXTRA_MYPY_OPTIONS ?= --follow-imports=skip
 EXTRA_FLAKE8_OPTIONS ?= --ignore="E501,E203,W503" --exclude=rwi.py
-EXTRA_PYDOCSTYLE_OPTIONS = --match='(?!(test_|rwi)).*\.py'
+EXTRA_PYDOCSTYLE_OPTIONS = --match='(?!(coverage|test_|rwi)).*\.py'
 
 all: srcstyle doctest
 

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ dependencies:
   - python<3.9
   - codecov
   - ipython
+  - mypy
   - numpy
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pytest-qt
   - qtpy>=1.9.0
   - scooby>=0.5.1
+  - toml
   - pip
   - pip:
       - vtk

--- a/ignore_words.txt
+++ b/ignore_words.txt
@@ -1,3 +1,4 @@
 lod
 byteorder
 flem
+PullRequest

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+ignore_errors = True
 disallow_untyped_defs = True
 
 [mypy-vtk.*]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,28 @@
 line-length = 88
 skip-string-normalization = true
 target-version = ["py39"]
-exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|node_modules|rwi\.py'
+# `pre-comment` doesn't see skips; `force-exclude` forces it
+# to see these files
+#
+# See:
+#   - https://github.com/psf/black/issues/1584
+force-exclude = '''
+(
+    docs/conf\.py
+  | pyvistaqt/rwi\.py
+  | tests/.*\.py
+  | setup.py
+)
+'''
 check = true
 
 [tool.pydocstyle]
-match = '(?!(coverage|test_|rwi)).*[.]py'
+match = '''
+(?!
+    (
+      | tests/
+      | docs/
+      | rwi
+    ).*\.py
+)
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 line-length = 88
 skip-string-normalization = true
 target-version = ["py39"]
-exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|node_modules'
+exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|node_modules|rwi\.py'
+check = true
 
 [tool.pydocstyle]
 match = '(?!(coverage|test_|rwi)).*[.]py'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+line-length = 88
+skip-string-normalization = true
+target-version = ["py39"]
+exclude='\.eggs|\.git|\.mypy_cache|\.tox|\.venv|_build|buck-out|build|dist|node_modules'
+
+[tool.pydocstyle]
+match = '(?!(coverage|test_|rwi)).*[.]py'

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -14,3 +14,4 @@ sphinx-notfound-page==0.8
 sphinx-rtd-theme==1.0.0
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-websupport==1.2.4
+toml==0.10.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ isort==5.10.1
 mypy==0.961
 numpy==1.21.6
 pycodestyle==2.8.0
-pydocstyle==6.1.1
+pydocstyle[toml]==6.1.1
 pylint==2.13.0
 pytest==7.1.2
 pytest-cov==3.0.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,7 +7,7 @@ isort==5.10.1
 mypy==0.961
 numpy==1.21.6
 pycodestyle==2.8.0
-pydocstyle[toml]==6.1.1
+pydocstyle==6.1.1
 pylint==2.13.0
 pytest==7.1.2
 pytest-cov==3.0.0
@@ -22,3 +22,4 @@ flake8-quotes==3.3.1
 check-jsonschema==0.16.1
 pre-commit==2.19.0
 pre-commit-hooks==4.3.0
+toml==0.10.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -16,3 +16,9 @@ pytest-qt==4.1.0
 pyvista==0.34.1
 QtPy==2.1.0
 scooby==0.5.12
+flake8-black==0.3.2
+flake8-isort==4.1.1
+flake8-quotes==3.3.1
+check-jsonschema==0.16.1
+pre-commit==2.19.0
+pre-commit-hooks==4.3.0

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,14 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Operating System :: POSIX',
         'Operating System :: MacOS',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 
     url='https://github.com/pyvista/pyvistaqt',
     keywords='vtk numpy plotting mesh qt',
-    python_requires='>=3.6.*',
+    python_requires='>=3.7.*',
     install_requires=[
         'pyvista>=0.32.0',
         'QtPy>=1.9.0',


### PR DESCRIPTION
The purpose of this PR is a series of formatting changes to bring `pyvistaqt` formatting tools up to date:

### Configuration Changes
- [x] Update minimum python required to 3.7 and trove classifiers to 3.7-3.9 (9c19230)
- [x] Add `.flake8` and `.codespellrc` configuration files, updating `ignore_words.txt` too (bd8914a)
- [x] Add `pyproject.toml` (ec25ae7)
  + Add  `black` and `pydocstyle` configuration options to `pyproject.toml` (matching options in `Makefile` and those in `pyvista` repo and adding corresponding support in `.isort.cfg`)
- [x] Add `pre-commit` (including `.pre-commit-config.yaml` file) (e041a8b)
  + [x] Fix known issues using `mypy`, `isort`, `black`, and `pydocstyle` with `pre-commit` (a07f259)
- [x] Update `environment.yml` to include `mypy` dependency (matching `pip` requirements) (ae09730)
- [x] Update `.pylintrc` to match files ignored in `Makefile` (c68e16d)
- [x] Align checking between `Makefile` and `pre-commit`, placing all options in config files and pointing to those. This ensures the same checks happen across different systems and all config changes happen in one place as a single source of truth. (31af1e5)
- [x] Add `toml` to requirements, `environment.yml`, and `ci/azure-pipelines.yml` (supports reading configurations from `pyproject.toml`) (a914a24)