### PR TITLE
fix(qvtkinteractor): fix native widget drawing

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -270,6 +270,9 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         self._first_time = False  # Crucial!
         LOG.debug("QtInteractor init stop")
 
+        window_ = QtGui.QWindow.fromWinId(self.winId())
+        self.createWindowContainer(window_, self)
+
     def _setup_interactor(self, off_screen: bool) -> None:
         if off_screen:
             self.iren: Any = None

--- a/pyvistaqt/rwi.py
+++ b/pyvistaqt/rwi.py
@@ -55,6 +55,7 @@ Changes by Chen Jintao, Aug. 2021
 Changes by Eric Larson and Guillaume Favelier, Apr. 2022
  Support for PyQt6
 """
+import os
 
 # Check whether a specific PyQt implementation was chosen
 try:
@@ -117,79 +118,37 @@ if QVTKRWIBase != "QWidget":
 if PyQtImpl == "PyQt6":
     if QVTKRWIBase == "QOpenGLWidget":
         from PyQt6.QtOpenGLWidgets import QOpenGLWidget
-    from PyQt6.QtWidgets import QWidget
-    from PyQt6.QtWidgets import QSizePolicy
-    from PyQt6.QtWidgets import QApplication
-    from PyQt6.QtWidgets import QMainWindow
+    from PyQt6.QtCore import QEvent, QObject, QSize, Qt, QTimer
     from PyQt6.QtGui import QCursor
-    from PyQt6.QtCore import Qt
-    from PyQt6.QtCore import QTimer
-    from PyQt6.QtCore import QObject
-    from PyQt6.QtCore import QSize
-    from PyQt6.QtCore import QEvent
+    from PyQt6.QtWidgets import QApplication, QMainWindow, QSizePolicy, QWidget
 elif PyQtImpl == "PySide6":
     if QVTKRWIBase == "QOpenGLWidget":
         from PySide6.QtOpenGLWidgets import QOpenGLWidget
-    from PySide6.QtWidgets import QWidget
-    from PySide6.QtWidgets import QSizePolicy
-    from PySide6.QtWidgets import QApplication
-    from PySide6.QtWidgets import QMainWindow
+    from PySide6.QtCore import QEvent, QObject, QSize, Qt, QTimer
     from PySide6.QtGui import QCursor
-    from PySide6.QtCore import Qt
-    from PySide6.QtCore import QTimer
-    from PySide6.QtCore import QObject
-    from PySide6.QtCore import QSize
-    from PySide6.QtCore import QEvent
+    from PySide6.QtWidgets import QApplication, QMainWindow, QSizePolicy, QWidget
 elif PyQtImpl == "PyQt5":
     if QVTKRWIBase == "QGLWidget":
         from PyQt5.QtOpenGL import QGLWidget
-    from PyQt5.QtWidgets import QWidget
-    from PyQt5.QtWidgets import QSizePolicy
-    from PyQt5.QtWidgets import QApplication
-    from PyQt5.QtWidgets import QMainWindow
+    from PyQt5.QtCore import QEvent, QObject, QSize, Qt, QTimer
     from PyQt5.QtGui import QCursor
-    from PyQt5.QtCore import Qt
-    from PyQt5.QtCore import QTimer
-    from PyQt5.QtCore import QObject
-    from PyQt5.QtCore import QSize
-    from PyQt5.QtCore import QEvent
+    from PyQt5.QtWidgets import QApplication, QMainWindow, QSizePolicy, QWidget
 elif PyQtImpl == "PySide2":
     if QVTKRWIBase == "QGLWidget":
         from PySide2.QtOpenGL import QGLWidget
-    from PySide2.QtWidgets import QWidget
-    from PySide2.QtWidgets import QSizePolicy
-    from PySide2.QtWidgets import QApplication
-    from PySide2.QtWidgets import QMainWindow
+    from PySide2.QtCore import QEvent, QObject, QSize, Qt, QTimer
     from PySide2.QtGui import QCursor
-    from PySide2.QtCore import Qt
-    from PySide2.QtCore import QTimer
-    from PySide2.QtCore import QObject
-    from PySide2.QtCore import QSize
-    from PySide2.QtCore import QEvent
+    from PySide2.QtWidgets import QApplication, QMainWindow, QSizePolicy, QWidget
 elif PyQtImpl == "PyQt4":
     if QVTKRWIBase == "QGLWidget":
         from PyQt4.QtOpenGL import QGLWidget
-    from PyQt4.QtGui import QWidget
-    from PyQt4.QtGui import QSizePolicy
-    from PyQt4.QtGui import QApplication
-    from PyQt4.QtGui import QMainWindow
-    from PyQt4.QtCore import Qt
-    from PyQt4.QtCore import QTimer
-    from PyQt4.QtCore import QObject
-    from PyQt4.QtCore import QSize
-    from PyQt4.QtCore import QEvent
+    from PyQt4.QtCore import QEvent, QObject, QSize, Qt, QTimer
+    from PyQt4.QtGui import QApplication, QMainWindow, QSizePolicy, QWidget
 elif PyQtImpl == "PySide":
     if QVTKRWIBase == "QGLWidget":
         from PySide.QtOpenGL import QGLWidget
-    from PySide.QtGui import QWidget
-    from PySide.QtGui import QSizePolicy
-    from PySide.QtGui import QApplication
-    from PySide.QtGui import QMainWindow
-    from PySide.QtCore import Qt
-    from PySide.QtCore import QTimer
-    from PySide.QtCore import QObject
-    from PySide.QtCore import QSize
-    from PySide.QtCore import QEvent
+    from PySide.QtCore import QEvent, QObject, QSize, Qt, QTimer
+    from PySide.QtGui import QApplication, QMainWindow, QSizePolicy, QWidget
 else:
     raise ImportError("Unknown PyQt implementation " + repr(PyQtImpl))
 
@@ -362,7 +321,7 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         # Python2
         if type(WId).__name__ == 'PyCObject':
-            from ctypes import pythonapi, c_void_p, py_object
+            from ctypes import c_void_p, py_object, pythonapi
 
             pythonapi.PyCObject_AsVoidPtr.restype  = c_void_p
             pythonapi.PyCObject_AsVoidPtr.argtypes = [py_object]
@@ -371,7 +330,7 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         # Python3
         elif type(WId).__name__ == 'PyCapsule':
-            from ctypes import pythonapi, c_void_p, py_object, c_char_p
+            from ctypes import c_char_p, c_void_p, py_object, pythonapi
 
             pythonapi.PyCapsule_GetName.restype = c_char_p
             pythonapi.PyCapsule_GetName.argtypes = [py_object]
@@ -397,7 +356,8 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
         # do all the necessary qt setup
         self.setAttribute(WidgetAttribute.WA_OpaquePaintEvent)
-        self.setAttribute(WidgetAttribute.WA_PaintOnScreen)
+        if os.name == 'posix':
+            self.setAttribute(WidgetAttribute.WA_PaintOnScreen)
         self.setMouseTracking(True) # get all mouse events
         self.setFocusPolicy(FocusPolicy.WheelFocus)
         self.setSizePolicy(QSizePolicy(SizePolicy.Expanding, SizePolicy.Expanding))
@@ -640,11 +600,12 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 def QVTKRenderWidgetConeExample(block=False):
     """A simple example that uses the QVTKRenderWindowInteractor class."""
 
-    from vtkmodules.vtkFiltersSources import vtkConeSource
-    from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper, vtkRenderer
+    import vtkmodules.vtkInteractionStyle
+
     # load implementations for rendering and interaction factory classes
     import vtkmodules.vtkRenderingOpenGL2
-    import vtkmodules.vtkInteractionStyle
+    from vtkmodules.vtkFiltersSources import vtkConeSource
+    from vtkmodules.vtkRenderingCore import vtkActor, vtkPolyDataMapper, vtkRenderer
 
     # every QT app needs an app
     app = QApplication.instance()


### PR DESCRIPTION
- Check if system ix `X11` before setting `WA_PaintOnScreen`
- Enable native widgets by using `createWindowContainer` in `QtInteractor`

Fixes #196 