### PR TITLE
MAINT: Set version for patch release

### DIFF
--- a/pyvistaqt/_version.py
+++ b/pyvistaqt/_version.py
@@ -1,6 +1,6 @@
 """Version info for pyvistaqt."""
 # major, minor, patch
-VERSION_INFO = 0, 10, "dev0"
+VERSION_INFO = 0, 9, 1
 
 # Nice string for the version
 __version__ = ".".join(map(str, VERSION_INFO))


### PR DESCRIPTION
It has been almost a year since our last release. This is just a bugfix release so I think 0.9.1 is appropriate, but we could do 0.10.0 instead if people want.