### PR TITLE
MAINT: Use setuptools_scm for versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ docs/external_examples.rst
 
 # vim
 *.swp
+
+pyvistaqt/_version.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -17,6 +17,7 @@ fail-under=10
 ignore=rwi.py,
        conf.py,
        conftest.py,
+       _version.py,
        setup.py  # ignore and fix in future PR
 
 # Add files or directories matching the regex patterns to the blacklist. The
@@ -527,5 +528,5 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/mypy_checklist.txt
+++ b/mypy_checklist.txt
@@ -1,4 +1,3 @@
-pyvistaqt/_version.py
 pyvistaqt/counter.py
 pyvistaqt/dialog.py
 pyvistaqt/editor.py

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -2,6 +2,7 @@
 
 try:
     from importlib.metadata import version
+
     __version__ = version("mne")
 except Exception:
     try:

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -4,7 +4,7 @@ try:
     from importlib.metadata import version
 
     __version__ = version("mne")
-except Exception:  # pylint: disable=broad-exception-caught
+except Exception:  # pragma: no cover # pylint: disable=broad-exception-caught
     try:
         from ._version import __version__
     except ImportError:

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -3,7 +3,7 @@
 try:
     from importlib.metadata import version
 
-    __version__ = version("mne")
+    __version__ = version("pyvistaqt")
 except Exception:  # pragma: no cover # pylint: disable=broad-exception-caught
     try:
         from ._version import __version__

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -4,7 +4,7 @@ try:
     from importlib.metadata import version
 
     __version__ = version("mne")
-except Exception:
+except Exception:  # pylint: disable=broad-exception-caught
     try:
         from ._version import __version__
     except ImportError:

--- a/pyvistaqt/__init__.py
+++ b/pyvistaqt/__init__.py
@@ -1,5 +1,13 @@
 """PyVista package for 3D plotting and mesh analysis."""
-from ._version import __version__
+
+try:
+    from importlib.metadata import version
+    __version__ = version("mne")
+except Exception:
+    try:
+        from ._version import __version__
+    except ImportError:
+        __version__ = '0.0.0'
 
 try:
     from qtpy import QtCore  # noqa

--- a/pyvistaqt/_version.py
+++ b/pyvistaqt/_version.py
@@ -1,6 +1,0 @@
-"""Version info for pyvistaqt."""
-# major, minor, patch
-VERSION_INFO = 0, 10, 'dev0'
-
-# Nice string for the version
-__version__ = ".".join(map(str, VERSION_INFO))

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,19 @@
 Installation file for python pyvistaqt module
 """
 import os
+from pathlib import Path
 from io import open as io_open
 
 from setuptools import setup
 
 package_name = 'pyvistaqt'
-
-__version__ = None
-filepath = os.path.dirname(__file__)
-version_file = os.path.join(filepath, package_name, '_version.py')
-with io_open(version_file, mode='r') as fd:
-    exec(fd.read())
-
-readme_file = os.path.join(filepath, 'README.rst')
+readme_file = Path(__file__).parent / 'README.rst'
 
 setup(
     name=package_name,
     packages=[package_name, package_name],
-    version=__version__,
     description='pyvista qt plotter',
-    long_description=io_open(readme_file, encoding="utf-8").read(),
+    long_description=readme_file.read_text(),
     long_description_content_type='text/x-rst',
     author='PyVista Developers',
     author_email='info@pyvista.org',
@@ -42,9 +35,15 @@ setup(
     url='https://github.com/pyvista/pyvistaqt',
     keywords='vtk numpy plotting mesh qt',
     python_requires='>=3.7',
+    setup_requires=["setuptools>=45", "setuptools_scm>=6.2"],
+    use_scm_version={
+        "write_to": "pyvistaqt/_version.py",
+        "version_scheme": "release-branch-semver",
+    },
     install_requires=[
         'pyvista>=0.32.0',
         'QtPy>=1.9.0',
+        "importlib_resources>=5.10.2; python_version<'3.9'",
     ],
     package_data={'pyvistaqt': [
         os.path.join('data', '*.png'),


### PR DESCRIPTION
In many repos I work with we've moved to `setuptools_scm` for version control. It's great because when you cut a release on GitHub with a tag like 0.10.0, that will automatically show up as the version in PyPI and sdist, but the next PR that gets merged will show up as `0.11.0.dev<bunch of info>`. It thus adds info and gets rid of the need to manually tick versions -- you can just cut a release on GitHub and be done.

The only downside I've noticed is that downstream packages need to do `git+https://github.com/pyvista/pyvistaqt` to install latest `main` rather than using a `zipball`, but this is a minor drawback and easily worked around I think.