### PR TITLE
DOC: Switch to pydata-sphinx-theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -90,7 +90,7 @@ release = pyvistaqt.__version__
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -112,10 +112,23 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-import sphinx_rtd_theme
+import pydata_sphinx_theme
 
-html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+html_theme = "pydata_sphinx_theme"
+html_context = {
+    "github_user": "pyvista",
+    "github_repo": "pyvista",
+    "github_version": "main",
+    "doc_path": "doc/source",
+    "examples_path": "examples",
+}
+html_show_sourcelink = False
+html_copy_source = False
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+html_show_sphinx = False
+
+html_theme = 'pydata_sphinx_theme'
 html_context = {
     # Enable the "Edit in GitHub link within the header of each page.
     'display_github': False,
@@ -138,7 +151,28 @@ html_context = {
 # documentation.
 #
 html_theme_options = {
-    'logo_only': True,
+    "show_prev_next": False,
+    "github_url": "https://github.com/pyvista/pyvistaqt",
+    "collapse_navigation": True,
+    "use_edit_page_button": True,
+    "icon_links": [
+        {
+            "name": "Slack Community",
+            "url": "http://slack.pyvista.org",
+            "icon": "fab fa-slack",
+        },
+        {
+            "name": "Support",
+            "url": "https://github.com/pyvista/pyvista/discussions",
+            "icon": "fa fa-comment fa-fw",
+        },
+        {
+            "name": "Contributing",
+            "url": "https://github.com/pyvista/pyvistaqt/blob/main/CONTRIBUTING.rst",
+            "icon": "fa fa-gavel fa-fw",
+        },
+    ],
+    "navbar_end": ["theme-switcher", "navbar-icon-links"],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,
@@ -154,8 +188,10 @@ htmlhelp_basename = 'pyvistaqtdoc'
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None,
-                       'https://docs.pyvista.org/': None,
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/", None),
+    "pyvista": ('https://docs.pyvista.org/', None),
+    "PySide6": ("https://doc.qt.io/qtforpython-6/", None),
 }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,10 +12,6 @@ Overview
    :target: https://anaconda.org/conda-forge/pyvistaqt
    :alt: conda-forge
 
-.. image:: https://dev.azure.com/pyvista/PyVista/_apis/build/status/pyvista.pyvistaqt?branchName=master
-   :target: https://dev.azure.com/pyvista/PyVista/_build/latest?definitionId=9&branchName=master
-   :alt: Azure Pipelines
-
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
    :target: https://opensource.org/licenses/MIT
    :alt: MIT License

--- a/requirements_docs.txt
+++ b/requirements_docs.txt
@@ -11,7 +11,7 @@ Sphinx==6.2.1
 sphinx-autobuild==2021.3.14
 sphinx-copybutton==0.5.2
 sphinx-notfound-page==0.8.3
-sphinx-rtd-theme==1.2.1
+pydata-sphinx-theme==0.13.3
 sphinxcontrib-napoleon==0.7
 sphinxcontrib-websupport==1.2.4
 toml==0.10.2


### PR DESCRIPTION
Should be done to match pyvista's docs. Looks okay locally:

<img width="1425" alt="Screenshot 2023-06-05 at 11 32 13 AM" src="https://github.com/pyvista/pyvistaqt/assets/2365790/bf7fbea9-e64e-4b13-bf32-6702147bc0f0">



@banesullivan do we need to do anything special to get this to upload to https://qtdocs.pyvista.org/ ? Not sure how/when that gets updated