### PR TITLE
MAINT: Reduce dependabot frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,14 @@ updates:
     directory: "/" # Location of package manifests
     insecure-external-code-execution: allow
     schedule:
-      interval: "daily"
+      interval: "monthly"
     labels:
       - "maintenance"
       - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "maintenance"
       - "dependencies"


### PR DESCRIPTION
I have been a bit unhappy at the frequency of dependabot emails, reviews, and merges that we've had to do. I think restricting `pip` to once per month is much more appropriate given the activity level of this repo. Restricting the actions to weekly seems good enough since they're rarely updated.