### PR TITLE
Bump flake8-isort to 6.1.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
   - id: flake8
     additional_dependencies: [
       "flake8-black==0.3.6",
-      "flake8-isort==6.0.0",
+      "flake8-isort==6.1.1",
       "flake8-quotes==3.3.2",
     ]
     args: [


### PR DESCRIPTION
Following https://github.com/pyvista/pyvista/pull/5538.