### PR TITLE
`PyQt6!=6.6.3` to fix integration test dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - run: pip install ${{ matrix.qt }}
         name: "Install Qt binding"
         if: matrix.qt != 'None'
-      - run: pip install "PyQt6-Qt6!=6.6.1,!=6.6.2" "PyQt6!=6.6.1,!=6.6.2"
+      - run: pip install "PyQt6-Qt6!=6.6.1,!=6.6.2,!=6.6.3" "PyQt6!=6.6.1,!=6.6.2,!=6.6.3"
         name: "Install PyQt6-Qt6"
         if: matrix.qt == 'PyQt6'
       - run: |


### PR DESCRIPTION
`PyQt6!=6.6.3` to fix integration test dependency.