### PR TITLE
BUG: Fix PySide6 compatibility

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -50,7 +50,6 @@ from typing import Any, Callable, Dict, Generator, List, Optional, Tuple, Type, 
 
 import numpy as np  # type: ignore
 import pyvista
-import scooby  # type: ignore
 from pyvista import global_theme
 
 try:
@@ -63,7 +62,7 @@ try:
     from pyvista.core.utilities import conditional_decorator, threaded
 except ImportError:  # PV < 0.40
     from pyvista.utilities import conditional_decorator, threaded
-from qtpy import QtCore
+from qtpy import QtCore, QtGui
 from qtpy.QtCore import QSize, QTimer, Signal
 from qtpy.QtWidgets import (
     QAction,
@@ -90,12 +89,6 @@ from .utils import (
     _setup_off_screen,
 )
 from .window import MainWindow
-
-if scooby.in_ipython():  # pragma: no cover
-    # pylint: disable=unused-import
-    from IPython.external.qt_for_kernel import QtGui
-else:
-    from qtpy import QtGui  # pylint: disable=ungrouped-imports
 
 LOG = logging.getLogger("pyvistaqt")
 LOG.setLevel(logging.CRITICAL)


### PR DESCRIPTION
So this is a problem:
```
$ python -c "from IPython.external.qt_for_kernel import QtGui; print(QtGui)"
<module 'PySide6.QtPrintSupport' from '/home/larsoner/python/virtualenvs/base/lib/python3.12/site-packages/PySide6/QtPrintSupport.abi3.so'>
```
The source file for `qt_for_external` says that it's kept for backward compat, so perhaps no surprise it doesn't work. I don't see any reason we need to triage based on being in ipython or not, though, given everything else comes from `qtpy` earlier anyway.

@tkoyama010 you added this in https://github.com/pyvista/pyvistaqt/pull/40/files#diff-bcab1285ff8ba2b1a25b18d87cd02a09eca4194b83196ba0c2b7939c76393d01R65, any recollection why it was necessary?