### PR TITLE
Do not access private `Renderer._actors` property

### DIFF
--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -60,7 +60,7 @@ class Editor(QDialog):
         """Update the internal widget list."""
         self.tree_widget.clear()
         for idx, renderer in enumerate(self.renderers):
-            actors = renderer._actors  # pylint: disable=protected-access
+            actors = renderer.actors
             widget_idx = self.stacked_widget.addWidget(_get_renderer_widget(renderer))
             top_item = QTreeWidgetItem(self.tree_widget, [f"Renderer {idx}"])
             top_item.setData(0, Qt.ItemDataRole.UserRole, widget_idx)


### PR DESCRIPTION
The `BackgroundPlotter` accesses a private variable of 3rd party imported class, i.e. `Renderer._actors`. But there is no need to access a private property here since `Renderer.actors` simply returns `Renderer._actors` already anyway.

See `Renderer.actors` source:
https://github.com/pyvista/pyvista/blob/5be64528b73a970df364b4e2dd7ebfa0b62e9b64/pyvista/plotting/renderer.py#L818-L821

The underlying implementation for  `Renderer._actors` is being modified by https://github.com/pyvista/pyvista/pull/7184 and the access to a private variable here by `pyvistaqt` is causing integration tests to fail unexpectedly.

EDIT: This was addressed upstream by implementing an `_actors.items()`  method, so this change is not strictly needed by https://github.com/pyvista/pyvista/pull/7184, but I still think access to private vars should be avoided here