### PR TITLE
Limit VTK to <9.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     install_requires=[
         'pyvista>=0.32.0',
         'QtPy>=1.9.0',
+        'vtk<9.4',
     ],
     package_data={'pyvistaqt': [
         os.path.join('data', '*.png'),


### PR DESCRIPTION
Per #697 

cc @user27182 @tkoyama010 

Proposing we limit VTK support here until we can figure out why there are flaky segfaults on VTK 9.4 with pyvistaqt

As long as this is on `main` we'll be good upstream in PyVista's integration tests so we don't even need to go through a release cycle for this