### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,7 @@
 name: "CI"
+permissions:
+  contents: read
+  statuses: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/5](https://github.com/pyvista/pyvistaqt/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the workflow's actions, the following permissions are necessary:
- `contents: read`: Required for actions like `actions/checkout@v4` to read the repository's contents.
- `statuses: write`: Required for reporting status checks, which might be used implicitly by some actions.

This change will ensure that the workflow operates with the least privileges necessary, reducing the risk of unintended access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
