### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: "CI"
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/4](https://github.com/pyvista/pyvistaqt/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow to define the minimal permissions required for the workflow. Based on the actions used in the workflow:
- `contents: read` is sufficient for most steps, such as `actions/checkout`.
- `contents: write` is not required as the workflow does not modify repository contents.
- `id-token: write` is not needed since no OpenID Connect (OIDC) tokens are fetched.
- `statuses: write` is not explicitly required unless commit statuses are updated, which is not evident in the provided workflow.

We will add the following permissions block at the root level:
```yaml
permissions:
  contents: read
```

This ensures that the workflow has only read access to the repository contents, adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
