### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -6,6 +6,9 @@ on:
       - "main"
 jobs:
   autoupdate:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Automatically update PR


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/3](https://github.com/pyvista/pyvistaqt/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow. Since the workflow interacts with pull requests, it requires `pull-requests: write` permission. Additionally, to ensure minimal permissions, set `contents: read` to allow basic repository access. These permissions should be added at the job level to scope them specifically to the `autoupdate` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
