### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -1,5 +1,9 @@
 name: Documentation
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/1](https://github.com/pyvista/pyvistaqt/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, the following permissions are needed:
- `contents: read` for accessing the repository's contents.
- `pages: write` for deploying the documentation to GitHub Pages.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs unless overridden by a job-specific `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
