### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: "CI"
+permissions:
+  contents: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/2](https://github.com/pyvista/pyvistaqt/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the actions used in the workflow:
- `contents: read` is sufficient for most steps, such as checking out the repository and running tests.
- `contents: write` is required for the `codecov/codecov-action` step to upload coverage reports.

The `permissions` block will be added at the root of the workflow to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
