### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-pr-branch.yml
+++ b/.github/workflows/update-pr-branch.yml
@@ -1,4 +1,7 @@
 name: PR update
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pyvista/pyvistaqt/security/code-scanning/6](https://github.com/pyvista/pyvistaqt/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Based on the workflow's purpose (updating pull requests), the `pull-requests: write` permission is necessary. Additionally, the `contents: read` permission is required for accessing repository contents, which is a common minimal permission.

The `permissions` block will be added after the `name` field and before the `on` field to apply these permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
