### PR TITLE
Check that `axes_widget` is truthy

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -15,13 +15,13 @@
 <script>
   (function (i, s, o, g, r, a, m) {
     i["GoogleAnalyticsObject"] = r;
-    (i[r] =
+    ((i[r] =
       i[r] ||
       function () {
         (i[r].q = i[r].q || []).push(arguments);
       }),
-      (i[r].l = 1 * new Date());
-    (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+      (i[r].l = 1 * new Date()));
+    ((a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]));
     a.async = 1;
     a.src = g;
     m.parentNode.insertBefore(a, m);

--- a/pyvistaqt/editor.py
+++ b/pyvistaqt/editor.py
@@ -88,7 +88,7 @@ def _get_renderer_widget(renderer: Renderer) -> QWidget:
     widget = QWidget()
     layout = QVBoxLayout()
     axes = QCheckBox("Axes")
-    if hasattr(renderer, "axes_widget"):
+    if getattr(renderer, "axes_widget", None):
         axes.setChecked(renderer.axes_widget.GetEnabled())
     else:
         axes.setChecked(False)


### PR DESCRIPTION
Upstream as part of https://github.com/pyvista/pyvista/pull/7716, setting dynamic attributes on the plotter will no longer be allowed. As such, `BasePlotter.axes_widget` is set to `None` during init. This means that it's no longer sufficient to check if the attribute exists, and it's necessary to also check it's not None.

I am seeing integration test failures here:
https://github.com/pyvista/pyvista/actions/runs/16335129476/job/46145621302?pr=7716#step:8:1177
I'm pretty sure they'll all be resolved by this PR