### PR TITLE
MAINT: Remove bots from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,5 +2,8 @@ changelog:
   exclude:
     authors:
       - dependabot
+      - dependabot[bot]
       - pre-commit-ci
+      - pre-commit-ci[bot]
       - github-actions
+      - github-actions[bot]


### PR DESCRIPTION
I want to cut a release to be compatible with PyVista when it comes out, but noticed the notes had a bunch of bot names in them. So I'll merge this then cut a 0.11.3