### PR TITLE
Use PyPI OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,6 @@ jobs:
         name: "Import without Qt"
         if: matrix.qt == 'None'
       - uses: codecov/codecov-action@v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: success()
         name: "Upload coverage to CodeCov"
 
@@ -159,8 +157,6 @@ jobs:
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: "Run Tests"
       - uses: codecov/codecov-action@v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: success()
         name: "Upload coverage to CodeCov"
 
@@ -201,7 +197,5 @@ jobs:
       - run: pytest -v --cov pyvistaqt --cov-report html
         name: "Run Tests"
       - uses: codecov/codecov-action@v6
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         if: success()
         name: "Upload coverage to CodeCov"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: "CI"
 permissions:
   statuses: write
   contents: write
+  id-token: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
@@ -77,6 +78,8 @@ jobs:
       - uses: codecov/codecov-action@v6
         if: success()
         name: "Upload coverage to CodeCov"
+        with:
+          use_oidc: true
 
   pip:
     name: ${{ matrix.os }} / pip / PyQt6 / pyvista-${{ matrix.pyvista }}${{ matrix.vtk && ' / vtk'}}${{ matrix.vtk }}
@@ -159,6 +162,8 @@ jobs:
       - uses: codecov/codecov-action@v6
         if: success()
         name: "Upload coverage to CodeCov"
+        with:
+          use_oidc: true
 
   conda:
     name: ${{ matrix.os }} / conda / ${{ matrix.qt }}
@@ -199,3 +204,5 @@ jobs:
       - uses: codecov/codecov-action@v6
         if: success()
         name: "Upload coverage to CodeCov"
+        with:
+          use_oidc: true

--- a/.github/workflows/docbuild.yml
+++ b/.github/workflows/docbuild.yml
@@ -1,7 +1,7 @@
 name: Documentation
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 on:
@@ -38,8 +38,7 @@ jobs:
         # Not a PR:
         if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads')
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          external_repository: pyvista/pyvistaqt-docs
-          publish_branch: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
           publish_dir: ./docs/_build/html
           cname: qtdocs.pyvista.org

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
     needs: package
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyvistaqt
+    permissions:
+      id-token: write # this permission is mandatory for trusted publishing
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -54,6 +59,3 @@ jobs:
           path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2017-2021 The PyVista Developers
+Copyright (c) 2017-2026 The PyVista Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

Migrate release workflow from PyPI API token auth to OIDC Trusted Publishing. Removes reliance on `PYPI_API_TOKEN` secret and adds `permissions: id-token: write` plus `environment: pypi`.

## Next steps

- [x] Add a Trusted Publisher on PyPI for this project: Account → Publishing → Add a new publisher (workflow: `release.yml`, environment: `pypi`).
- [x] Add `pyvistaqt` to the `pyvista` PyPI organization.
- [x] After first successful OIDC release, delete the old PyPI API token and revoke the `PYPI_API_TOKEN` Actions secret.