### PR TITLE
Audit README and docs badges for accuracy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,6 @@ PyVistaQt
    :target: https://anaconda.org/conda-forge/pyvistaqt
    :alt: conda-forge
 
-.. image:: https://dev.azure.com/pyvista/PyVista/_apis/build/status/pyvista.pyvistaqt?branchName=main
-   :target: https://dev.azure.com/pyvista/PyVista/_build/latest?definitionId=9&branchName=main
-   :alt: Azure Pipelines
-
 .. image:: https://github.com/pyvista/pyvistaqt/actions/workflows/ci.yml/badge.svg?branch=main
    :target: https://github.com/pyvista/pyvistaqt/actions?query=branch:main+event:push
    :alt: GitHub Actions
@@ -27,21 +23,13 @@ PyVistaQt
   :target: https://codecov.io/gh/pyvista/pyvistaqt
   :alt: Codecov
 
-.. image:: https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat
-  :target: https://timothycrosley.github.io/isort
-  :alt: isort
-
-.. image:: https://img.shields.io/badge/%20linter-pylint-%231674b1?style=flat
-  :target: https://github.com/PyCQA/pylint
-  :alt: pylint
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+  :target: https://github.com/astral-sh/ruff
+  :alt: Ruff
 
 .. image:: https://img.shields.io/badge/%20type_checker-mypy-%231674b1?style=flat
   :target: https://github.com/python/mypy
   :alt: mypy
-
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg?style=flat
-  :target: https://github.com/psf/black
-  :alt: black
 
 ``pyvistaqt`` is a helper module for ``pyvista`` to enable you to
 plot using Qt by placing a vtk-widget into a background renderer.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,13 +85,12 @@ License
 ``pyvistaqt`` is under the MIT license.
 However, Qt bindings have licenses of their own.
 
-Historically, ``pyvistaqt`` has used ``pyqt5``, which is subject
-to the GPL license. See details at
-`Riverbank License FAQ <https://www.riverbankcomputing.com/commercial/license-faq>`_.
-
-``pyvistaqt`` is transitioning to using ``qtpy``
+``pyvistaqt`` uses ``qtpy`` to abstract over the underlying Qt binding:
 
 > QtPy is a small abstraction layer that lets you write applications using a single API call to either PyQt or PySide.
 
-Please refer to the `QtPy documentation <https://github.com/spyder-ide/qtpy>`_
-to learn more.
+This means the Qt binding actually installed at runtime (e.g. ``PyQt5``,
+``PyQt6``, ``PySide2``, ``PySide6``) determines the license obligations
+for the Qt layer of your application. Please refer to the
+`QtPy documentation <https://github.com/spyder-ide/qtpy>`_ and the
+license of the binding you install to learn more.


### PR DESCRIPTION
## Summary

Audit of the badges and content in `README.rst` and `docs/index.rst`. Several badges no longer reflect the project's actual toolchain.

### Stale badges removed from `README.rst`

- **Azure Pipelines** — no `azure-pipelines.yml` exists in the repo; CI runs entirely on GitHub Actions (`.github/workflows/ci.yml`).
- **isort** — import sorting is handled by `[tool.ruff.lint.isort]` in `pyproject.toml`; there is no standalone `isort` dependency.
- **pylint** — linting is done by ruff (`select = ["ALL"]`); there is no pylint config.
- **black** — formatting is done by `ruff-format` (see `[tool.ruff.format]` and `.pre-commit-config.yaml`); there is no black dependency.

### Added

- **Ruff** badge in place of the three tool badges above, reflecting what is actually configured and enforced via pre-commit.

### `docs/index.rst` License section

The qtpy migration referenced as "in progress" has been complete for some time ... `QtPy>=1.9.0` is a required dependency in `pyproject.toml` and all first-party modules import from `qtpy`. The license paragraph is rewritten to describe the current state: pyvistaqt is MIT, and the Qt-layer license depends on whichever binding the user installs at runtime.