### PR TITLE
BUG: Attach attrs to archives

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst


### PR DESCRIPTION
This should allow this command:
```
$ pip install 'pyvistaqt @ https://github.com/pyvista/pyvistaqt/archive/refs/heads/main.zip'
...
      LookupError: setuptools-scm was unable to detect version for /tmp/pip-install-wphov8yc/pyvistaqt_90b6ded43f5f4f1eb7edba6e5e8378f6.
      
      Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata and will not work.
      
      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use git+https://github.com/user/proj.git#egg=proj
      
      Alternatively, set the version with the environment variable SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in https://setuptools-scm.readthedocs.io/en/latest/config/
```
to succeed (correctly determine version)

Will merge and verify it works. Adapted from MNE-Python so I expect it to.