### PR TITLE
Fix bug with callback message formatting

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -nWT --keep-going
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = pyvistaqt
 SOURCEDIR     = .

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,7 +231,7 @@ from docutils.parsers.rst import directives  # noqa: E402
 
 # -- Autosummary options
 from sphinx.ext.autosummary import Autosummary  # noqa: E402
-from sphinx.ext.autosummary import get_documenter  # noqa: E402
+from sphinx.ext.autosummary import _get_documenter  # noqa: E402
 from sphinx.util.inspect import safe_getattr  # noqa: E402
 
 
@@ -251,7 +251,7 @@ class AutoAutoSummary(Autosummary):  # noqa: D101
         items = []
         for name in sorted(obj.__dict__.keys()):  # dir(obj):
             try:
-                documenter = get_documenter(AutoAutoSummary.app, safe_getattr(obj, name), obj)
+                documenter = _get_documenter(AutoAutoSummary.app, safe_getattr(obj, name), obj)
             except AttributeError:
                 continue
             if documenter.objtype in typ:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ test = [
     "sphinx_gallery==0.21.0",
 ]
 docs = [
-    "pydata-sphinx-theme==0.19.0",
-    "Sphinx==8.1.3",  # 8.2+ requires Python 3.11+
-    "sphinx-copybutton==0.5.2",
-    "sphinx-notfound-page==1.1.0",
+    "pydata-sphinx-theme",
+    "Sphinx",
+    "sphinx-copybutton",
+    "sphinx-notfound-page",
 ]
 dev = [
     "pre-commit",

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -218,7 +218,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
     ) -> None:
         """Initialize Qt interactor."""
         LOG.debug("QtInteractor init start")
-        self.url: QtCore.QUrl | None = None
+        self._url: QtCore.QUrl | None = None
 
         # Cannot use super() here because
         # QVTKRenderWindowInteractor silently swallows all kwargs
@@ -400,8 +400,8 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         """Event is called after dragEnterEvent."""
         try:
             for url in event.mimeData().urls():
-                self.url = url
-                filename = self.url.path()
+                self._url = url
+                filename = self._url.path()
                 if os.path.isfile(filename):  # noqa: PTH113
                     self.add_mesh(pyvista.read(filename))
         except OSError as exception:  # pragma: no cover

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -107,6 +107,7 @@ from .utils import _create_menu_bar
 from .utils import _setup_application
 from .utils import _setup_ipython
 from .utils import _setup_off_screen
+from .utils import _setup_terminal_output_fix
 from .window import MainWindow
 
 LOG = logging.getLogger("pyvistaqt")
@@ -565,6 +566,7 @@ class BackgroundPlotter(QtInteractor):
         self.ipython = _setup_ipython()
         LOG.debug("BackgroundPlotter init setup app")
         self.app = _setup_application(app)
+        _setup_terminal_output_fix(self.app)
         LOG.debug("BackgroundPlotter init setup offscreen")
         self.off_screen = _setup_off_screen(off_screen)
         if app_window_class is None:

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -409,7 +409,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
 
     def close(self) -> None:  # ty: ignore[invalid-method-override]
         """Quit application (intentionally returns None, unlike QWidget.close)."""
-        if self._closed:
+        if getattr(self, "_closed", True):  # if it doesn't exist, error during init
             return
         if hasattr(self, "render_timer"):
             self.render_timer.stop()

--- a/pyvistaqt/utils.py
+++ b/pyvistaqt/utils.py
@@ -1,9 +1,12 @@
 """This module contains utilities routines."""  # noqa: D404
 
+import contextlib
+import sys
 from typing import Any
 from typing import cast
 
 import pyvista
+from qtpy import QtCore
 from qtpy.QtWidgets import QApplication
 from qtpy.QtWidgets import QMenuBar
 import scooby
@@ -61,3 +64,102 @@ def _setup_off_screen(off_screen: bool | None = None) -> bool:  # noqa: FBT001
     if off_screen is None:
         off_screen = pyvista.OFF_SCREEN
     return off_screen
+
+
+# Strong references to the installed guards, keyed by their application, so
+# that the connected slots are not garbage collected and each application is
+# only wired up once.
+_TERMINAL_OUTPUT_GUARDS: list[tuple[QApplication, "_TerminalOpostGuard"]] = []
+
+
+class _TerminalOpostGuard:
+    """
+    Force terminal output post-processing on while Qt processes events.
+
+    See :func:`_setup_terminal_output_fix` for why this is needed. ``enable``
+    is connected to the event dispatcher's ``awake`` signal and ``restore`` to
+    ``aboutToBlock``, so the terminal is only touched while it is in raw mode
+    and is always handed back to the REPL in its original state.
+    """
+
+    def __init__(self, fd: int) -> None:
+        import termios  # noqa: PLC0415
+
+        self._fd = fd
+        self._termios = termios
+        self._saved: list[Any] | None = None
+
+    def enable(self) -> None:
+        """Restore ``OPOST``/``ONLCR`` if the terminal is in raw mode."""
+        termios = self._termios
+        try:
+            attrs = termios.tcgetattr(self._fd)
+        except termios.error:  # pragma: no cover
+            return
+        if attrs[1] & termios.OPOST:  # already sane, nothing to do
+            return
+        new = list(attrs)
+        new[1] = attrs[1] | termios.OPOST | termios.ONLCR
+        try:
+            termios.tcsetattr(self._fd, termios.TCSANOW, new)
+        except termios.error:  # pragma: no cover
+            return
+        self._saved = attrs
+
+    def restore(self) -> None:
+        """Put the terminal back the way the REPL left it."""
+        if self._saved is None:
+            return
+        with contextlib.suppress(self._termios.error):
+            self._termios.tcsetattr(self._fd, self._termios.TCSANOW, self._saved)
+        self._saved = None
+
+
+def _terminal_output_fd() -> int | None:
+    """Return the fd of the controlling terminal, or None if not a TTY/POSIX."""
+    try:
+        import termios  # noqa: PLC0415
+    except ImportError:  # pragma: no cover  # non-POSIX (e.g. Windows)
+        return None
+    for stream in (sys.stderr, sys.stdout):
+        try:
+            fd = stream.fileno()
+            termios.tcgetattr(fd)
+        except (OSError, ValueError, termios.error):
+            continue
+        return fd
+    return None
+
+
+def _setup_terminal_output_fix(app: QApplication) -> None:
+    """
+    Keep terminal output readable while Qt processes events.
+
+    Python 3.13's new interactive REPL (``pyrepl``) reads input with terminal
+    output post-processing (``OPOST``) disabled, and processes Qt events via
+    ``PyOS_InputHook`` while still in that raw state. Any text written to the
+    terminal during event processing -- for example a traceback surfaced by
+    ``pyvista``'s ``try_callback`` from an event callback -- then lacks
+    carriage returns and "staircases" down the screen. Restore
+    ``OPOST``/``ONLCR`` while Qt is processing events, and hand the terminal
+    back to the REPL unchanged afterwards.
+
+    This is a no-op unless we are in an interactive session attached to a
+    terminal on a POSIX platform, and even then only takes effect while the
+    terminal is actually in raw mode.
+    """
+    # Only meaningful for an interactive session attached to a terminal.
+    if not hasattr(sys, "ps1") and not sys.flags.interactive:
+        return
+    if any(existing is app for existing, _ in _TERMINAL_OUTPUT_GUARDS):
+        return  # already installed for this application
+    fd = _terminal_output_fd()
+    if fd is None:
+        return
+    dispatcher = QtCore.QAbstractEventDispatcher.instance()
+    if dispatcher is None:
+        return
+    guard = _TerminalOpostGuard(fd)
+    dispatcher.awake.connect(guard.enable)
+    dispatcher.aboutToBlock.connect(guard.restore)
+    _TERMINAL_OUTPUT_GUARDS.append((app, guard))

--- a/pyvistaqt/utils.py
+++ b/pyvistaqt/utils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import sys
+from types import ModuleType
 from typing import Any
 from typing import cast
 
@@ -10,6 +11,11 @@ from qtpy import QtCore
 from qtpy.QtWidgets import QApplication
 from qtpy.QtWidgets import QMenuBar
 import scooby
+
+try:
+    import termios
+except Exception:  # noqa: BLE001
+    termios: ModuleType | None = None  # type: ignore[assignment]  # non-POSIX (e.g. Windows)
 
 
 def _check_type(var: Any, var_name: str, var_types: list[type[Any]]) -> None:  # noqa: ANN401
@@ -83,15 +89,13 @@ class _TerminalOpostGuard:
     """
 
     def __init__(self, fd: int) -> None:
-        import termios  # noqa: PLC0415
 
         self._fd = fd
-        self._termios = termios
         self._saved: list[Any] | None = None
 
     def enable(self) -> None:
         """Restore ``OPOST``/``ONLCR`` if the terminal is in raw mode."""
-        termios = self._termios
+        assert termios is not None  # noqa:S101
         try:
             attrs = termios.tcgetattr(self._fd)
         except termios.error:  # pragma: no cover
@@ -110,16 +114,15 @@ class _TerminalOpostGuard:
         """Put the terminal back the way the REPL left it."""
         if self._saved is None:
             return
-        with contextlib.suppress(self._termios.error):
-            self._termios.tcsetattr(self._fd, self._termios.TCSANOW, self._saved)
+        assert termios is not None  # noqa:S101
+        with contextlib.suppress(termios.error):
+            termios.tcsetattr(self._fd, termios.TCSANOW, self._saved)
         self._saved = None
 
 
 def _terminal_output_fd() -> int | None:
     """Return the fd of the controlling terminal, or None if not a TTY/POSIX."""
-    try:
-        import termios  # noqa: PLC0415
-    except ImportError:  # pragma: no cover  # non-POSIX (e.g. Windows)
+    if termios is None:  # pragma: no cover  # non-POSIX (e.g. Windows)
         return None
     for stream in (sys.stderr, sys.stdout):
         try:

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -107,6 +107,51 @@ def test_setup_application(qapp) -> None:  # noqa: D103
     _setup_application(qapp)
 
 
+def test_setup_terminal_output_fix_noop_when_not_interactive(qapp) -> None:
+    """The terminal fix must not install itself outside an interactive REPL."""
+    from pyvistaqt.utils import _TERMINAL_OUTPUT_GUARDS  # noqa: PLC0415
+    from pyvistaqt.utils import _setup_terminal_output_fix  # noqa: PLC0415
+
+    # pytest is not run with ``python -i``, so neither ``sys.ps1`` nor the
+    # interactive flag is set and the guard must be a no-op.
+    assert not hasattr(sys, "ps1")
+    assert not sys.flags.interactive
+    before = len(_TERMINAL_OUTPUT_GUARDS)
+    _setup_terminal_output_fix(qapp)
+    assert len(_TERMINAL_OUTPUT_GUARDS) == before
+
+
+def test_terminal_opost_guard(monkeypatch) -> None:
+    """The guard restores OPOST while events run, then hands the tty back raw."""
+    termios = pytest.importorskip("termios")
+    from pyvistaqt.utils import _TerminalOpostGuard  # noqa: PLC0415
+
+    # A terminal in raw mode: output post-processing (index 1 == oflag) cleared.
+    state = [[0, 0, 0, 0, 0, 0, []]]
+
+    def fake_tcgetattr(_fd: int) -> list:
+        return list(state[0])
+
+    def fake_tcsetattr(_fd: int, _when: int, attrs: list) -> None:
+        state[0] = list(attrs)
+
+    monkeypatch.setattr(termios, "tcgetattr", fake_tcgetattr)
+    monkeypatch.setattr(termios, "tcsetattr", fake_tcsetattr)
+
+    guard = _TerminalOpostGuard(fd=1)
+    guard.enable()
+    assert state[0][1] & termios.OPOST  # post-processing turned back on
+    assert state[0][1] & termios.ONLCR
+    guard.restore()
+    assert not state[0][1] & termios.OPOST  # handed back exactly as it was
+
+    # ``enable`` is a no-op when the terminal is already sane.
+    state[0][1] = termios.OPOST | termios.ONLCR
+    guard.enable()
+    guard.restore()  # nothing saved -> no change
+    assert state[0][1] == termios.OPOST | termios.ONLCR
+
+
 def test_file_dialog(tmpdir, qtbot) -> None:  # noqa: D103
     dialog = FileDialog(
         filefilter=None,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -52,9 +52,12 @@ from pyvistaqt.editor import Editor
 from pyvistaqt.plotting import Counter
 from pyvistaqt.plotting import QTimer
 from pyvistaqt.plotting import QVTKRenderWindowInteractor
+from pyvistaqt.utils import _TERMINAL_OUTPUT_GUARDS
 from pyvistaqt.utils import _check_type
 from pyvistaqt.utils import _create_menu_bar
 from pyvistaqt.utils import _setup_application
+from pyvistaqt.utils import _setup_terminal_output_fix
+from pyvistaqt.utils import _TerminalOpostGuard
 
 
 class TstWindow(MainWindow):  # noqa: D101
@@ -109,9 +112,6 @@ def test_setup_application(qapp) -> None:  # noqa: D103
 
 def test_setup_terminal_output_fix_noop_when_not_interactive(qapp) -> None:
     """The terminal fix must not install itself outside an interactive REPL."""
-    from pyvistaqt.utils import _TERMINAL_OUTPUT_GUARDS  # noqa: PLC0415
-    from pyvistaqt.utils import _setup_terminal_output_fix  # noqa: PLC0415
-
     # pytest is not run with ``python -i``, so neither ``sys.ps1`` nor the
     # interactive flag is set and the guard must be a no-op.
     assert not hasattr(sys, "ps1")
@@ -124,7 +124,6 @@ def test_setup_terminal_output_fix_noop_when_not_interactive(qapp) -> None:
 def test_terminal_opost_guard(monkeypatch) -> None:
     """The guard restores OPOST while events run, then hands the tty back raw."""
     termios = pytest.importorskip("termios")
-    from pyvistaqt.utils import _TerminalOpostGuard  # noqa: PLC0415
 
     # A terminal in raw mode: output post-processing (index 1 == oflag) cleared.
     state = [[0, 0, 0, 0, 0, 0, []]]


### PR DESCRIPTION
Coupled with https://github.com/pyvista/pyvista/pull/8803, makes error messages in event handlers propagate properly. Diagnosed and fixed with Claude Opus 4.8 (and it was really tricky!).