### PR TITLE
Fix bug with multi-window crashing

### DIFF
--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -278,7 +278,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
             # ensures the render window stays updated without consuming too
             # many resources.
             twait = int((auto_update**-1) * 1000.0)
-            self.render_timer.timeout.connect(self.render)
+            self.render_timer.timeout.connect(self._auto_render)
             self.render_timer.start(twait)
 
         if global_theme.depth_peeling["enabled"] and self.enable_depth_peeling():
@@ -292,6 +292,7 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         LOG.debug("QtInteractor init stop")
 
     def _setup_interactor(self, off_screen: bool) -> None:  # noqa: FBT001
+        self._off_screen = off_screen
         if off_screen:
             self.iren: Any = None
         else:
@@ -323,9 +324,28 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         """Wrap ``BasePlotter.render``."""
         return BasePlotter.render(self, *args, **kwargs)
 
+    def _auto_render(self) -> None:
+        """
+        Render from the auto-update timer, skipping unsafe window states.
+
+        The render timer keeps ticking for the lifetime of the widget, but it
+        must not render an on-screen interactor whose window is not currently
+        visible (for example, one the user has just closed). Rendering then
+        calls into an unmapped or finalized OpenGL context, which can freeze
+        or crash *other* ``QtInteractor`` windows that share that context.
+        See issue #762.
+        """
+        if not getattr(self, "_off_screen", False) and not self.isVisible():
+            return
+        self.render()
+
     @conditional_decorator(threaded, platform.system() == "Darwin")
     def render(self) -> None:
         """Override the ``render`` method to handle threading issues."""
+        # Never render after the plotter has been closed: the render window has
+        # been finalized and touching its OpenGL context can crash (see #762).
+        if getattr(self, "_closed", False):
+            return None
         self._rendered = True  # Crucial for BasePlotter to know this has rendered
         try:
             return self.render_signal.emit()
@@ -406,6 +426,12 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
                     self.add_mesh(pyvista.read(filename))
         except OSError as exception:  # pragma: no cover
             warnings.warn(f"Exception when dropping files: {exception!s}")  # noqa: B028
+
+    def closeEvent(self, evt: QtGui.QCloseEvent) -> None:  # noqa: N802
+        """Stop the render timer before the widget is finalized (see #762)."""
+        if hasattr(self, "render_timer"):
+            self.render_timer.stop()
+        super().closeEvent(evt)
 
     def close(self) -> None:  # ty: ignore[invalid-method-override]
         """Quit application (intentionally returns None, unlike QWidget.close)."""

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -440,6 +440,61 @@ def test_qt_interactor(qtbot, plotting, ensure_closed) -> None:  # noqa: ARG001,
     assert vtk_widget._closed  # noqa: SLF001
 
 
+def test_auto_render_skips_hidden_window(qtbot, plotting, ensure_closed) -> None:  # noqa: ARG001
+    """
+    Auto-update timer must not render a hidden on-screen window (see #762).
+
+    When two ``QtInteractor`` windows share an OpenGL context, letting a closed
+    (hidden) window's render timer keep firing renders into an unmapped or
+    finalized GL context, which freezes or crashes the *other* window. The
+    timer callback must therefore skip rendering while the on-screen widget is
+    not visible.
+    """
+    plotter = BackgroundPlotter(show=False, off_screen=False, update_app_icon=False)
+    qtbot.addWidget(plotter.app_window)
+    plotter.render_timer.stop()  # drive _auto_render manually and deterministically
+    plotter.add_mesh(pyvista.Sphere())
+
+    calls = []
+    plotter.render = lambda *args, **kwargs: calls.append(True)  # noqa: ARG005
+
+    # Not shown yet -> not visible -> the timer callback must skip rendering.
+    assert not plotter.isVisible()
+    plotter._auto_render()  # noqa: SLF001
+    assert calls == []
+
+    # Once visible, the timer callback renders normally.
+    with wait_exposed(qtbot, plotter.app_window):
+        plotter.app_window.show()
+    assert plotter.isVisible()
+    plotter._auto_render()  # noqa: SLF001
+    assert calls == [True]
+
+    plotter.close()
+
+
+def test_auto_render_offscreen_and_after_close(qtbot, plotting, ensure_closed) -> None:  # noqa: ARG001
+    """Off-screen still auto-renders; render() is a no-op after close (#762)."""
+    plotter = BackgroundPlotter(show=False, off_screen=True, update_app_icon=False)
+    qtbot.addWidget(plotter.app_window)
+    plotter.render_timer.stop()  # drive _auto_render manually and deterministically
+    plotter.add_mesh(pyvista.Sphere())
+
+    calls = []
+    plotter.render = lambda *args, **kwargs: calls.append(True)  # noqa: ARG005
+    # Off-screen interactors are never "visible" but must still render.
+    assert not plotter.isVisible()
+    plotter._auto_render()  # noqa: SLF001
+    assert calls == [True]
+
+    # After close, the real render() must be a guarded no-op: the render window
+    # has been finalized and touching its GL context can crash.
+    del plotter.render  # restore the real, guarded render()
+    plotter.close()
+    assert plotter._closed  # noqa: SLF001
+    plotter.render()  # must not raise
+
+
 @pytest.mark.parametrize(
     "show_plotter",
     [


### PR DESCRIPTION
Closes #762 . Replicated with:

<details>
<summary>MWE</summary>

```
"""MWE for pyvistaqt#762: closing one of two QtInteractor windows freezes the other.

Run on a REAL display (NOT offscreen):

    python mwe_762.py

Two windows open, each with its own QtInteractor. ~2 s later the first window is
closed. Before the fix, the second window freezes -- and intermittently hard
crashes with SIGSEGV on some GPU drivers (e.g. NVIDIA) -- because the closed
window's auto-update render timer keeps rendering into an OpenGL context that is
shared between the windows and is now invalid. After the fix the script prints
"OK: survived" and exits cleanly (exit code 0).

Tip: the freeze is most obvious interactively -- delete the two singleShot lines,
close "Window 1" by hand, then try to rotate "Window 2".
"""

import sys

from qtpy import QtWidgets, QtCore

import pyvista as pv
from pyvistaqt import QtInteractor


def make_window(title, mesh):
    win = QtWidgets.QMainWindow()
    win.setWindowTitle(title)
    frame = QtWidgets.QFrame()
    layout = QtWidgets.QVBoxLayout(frame)
    plotter = QtInteractor(frame)  # default auto_update=5.0 -> render timer
    layout.addWidget(plotter.interactor)
    win.setCentralWidget(frame)
    plotter.add_mesh(mesh)
    win.resize(400, 300)
    win.show()
    return win, plotter


app = QtWidgets.QApplication(sys.argv)
app.setQuitOnLastWindowClosed(False)

win1, _ = make_window("Window 1 (will be closed)", pv.Sphere())
win2, _ = make_window("Window 2 (should survive)", pv.Cube())

QtCore.QTimer.singleShot(2000, win1.close)
QtCore.QTimer.singleShot(4000, lambda: print("OK: survived", flush=True))
QtCore.QTimer.singleShot(4500, app.quit)

app.exec() if hasattr(app, "exec") else app.exec_()
```

</details>

Turned out to be a timer issue. Adds a guard to `render` plus links to an `_auto_render` instead of plain `render` that *also* has a guard.