### PR TITLE
Check for wayland early

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -71,10 +71,16 @@ sphere.
 
 .. important::
 
-   On Linux/Wayland, Qt may currently require forcing the XCB platform
-   plugin for ``pyvistaqt`` to work correctly. You can set
-   ``QT_QPA_PLATFORM=xcb`` directly in your script before importing
-   Qt-related modules:
+   ``pyvistaqt`` embeds VTK through an X11 render window, which cannot draw
+   into a native Wayland surface. On a Wayland session it therefore needs the
+   XWayland (``xcb``) Qt platform plugin (see
+   `issue #445 <https://github.com/pyvista/pyvistaqt/issues/445>`_).
+
+   When ``pyvistaqt`` creates the ``QApplication`` itself, it now selects
+   ``xcb`` automatically (unless you pin ``QT_QPA_PLATFORM``). If you create
+   the ``QApplication`` yourself, set ``QT_QPA_PLATFORM=xcb`` *before* doing
+   so -- otherwise on-screen plotting raises a ``RuntimeError``. The most
+   portable way is to set it at the very top of your script:
 
    .. code:: python
 

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -103,6 +103,7 @@ from .dialog import ScaleAxesDialog
 from .editor import Editor
 from .rwi import QVTKRenderWindowInteractor
 from .utils import _check_type
+from .utils import _check_wayland
 from .utils import _create_menu_bar
 from .utils import _setup_application
 from .utils import _setup_ipython
@@ -219,6 +220,10 @@ class QtInteractor(QVTKRenderWindowInteractor, BasePlotter):
         """Initialize Qt interactor."""
         LOG.debug("QtInteractor init start")
         self._url: QtCore.QUrl | None = None
+
+        # Guard against a native-Wayland platform plugin, which makes the
+        # X11-based VTK render window abort with a fatal BadWindow (gh-445).
+        _check_wayland(pyvista.OFF_SCREEN if off_screen is None else off_screen)
 
         # Cannot use super() here because
         # QVTKRenderWindowInteractor silently swallows all kwargs

--- a/pyvistaqt/utils.py
+++ b/pyvistaqt/utils.py
@@ -1,6 +1,8 @@
 """This module contains utilities routines."""  # noqa: D404
 
+from collections.abc import Generator
 import contextlib
+import os
 import sys
 from types import ModuleType
 from typing import Any
@@ -55,6 +57,44 @@ def _setup_ipython(ipython: Any = None) -> Any:  # noqa: ANN401
     return ipython
 
 
+@contextlib.contextmanager
+def _prefer_xcb_on_wayland() -> Generator[None, None, None]:
+    """
+    Temporarily prefer the XWayland (``xcb``) Qt platform plugin on Wayland.
+
+    VTK's Linux render window is X11-based (``vtkXOpenGLRenderWindow``) and
+    cannot embed into a native Wayland surface, so a native-Wayland
+    ``QApplication`` makes :class:`~pyvistaqt.QtInteractor` abort with a fatal,
+    uncatchable ``X Error ... BadWindow`` as soon as it is realized (see
+    `issue #445 <https://github.com/pyvista/pyvistaqt/issues/445>`_).
+
+    When ``pyvistaqt`` is the one creating the ``QApplication`` and the user has
+    not pinned ``QT_QPA_PLATFORM``, set ``QT_QPA_PLATFORM=xcb`` for the duration
+    of this context if a Wayland session with XWayland is detected, then restore
+    ``os.environ`` to its previous state. Qt only reads the variable while the
+    ``QApplication`` is constructed, so wrap that call; setting
+    ``QT_QPA_PLATFORM`` yourself (e.g. to ``wayland``) opts out.
+    """
+    should_prefer = (
+        QApplication.instance() is None  # too late once the plugin is chosen
+        and not os.environ.get("QT_QPA_PLATFORM")  # respect an explicit choice
+        and bool(os.environ.get("WAYLAND_DISPLAY"))  # a Wayland session
+        and bool(os.environ.get("DISPLAY"))  # with XWayland to fall back to
+    )
+    if not should_prefer:
+        yield
+        return
+    original = os.environ.get("QT_QPA_PLATFORM")
+    os.environ["QT_QPA_PLATFORM"] = "xcb"
+    try:
+        yield
+    finally:
+        if original is None:
+            os.environ.pop("QT_QPA_PLATFORM", None)
+        else:  # an empty-string override was set: put it back verbatim
+            os.environ["QT_QPA_PLATFORM"] = original
+
+
 def _setup_application(app: QApplication | None = None) -> QApplication:
     # run within python
     if app is None:
@@ -62,8 +102,43 @@ def _setup_application(app: QApplication | None = None) -> QApplication:
         # base class, but for a Qt widgets app it is a QApplication.
         app = cast("QApplication | None", QApplication.instance())
         if not app:  # pragma: no cover
-            app = QApplication(["PyVista"])
+            with _prefer_xcb_on_wayland():
+                app = QApplication(["PyVista"])
     return app
+
+
+def _check_wayland(off_screen: bool) -> None:  # noqa: FBT001
+    """
+    Fail early with guidance on an unsupported native-Wayland platform plugin.
+
+    If we reach on-screen setup with a native Wayland ``QApplication`` already
+    created (so :func:`_prefer_xcb_on_wayland` could not intervene), VTK's X11
+    render window will abort the process with ``X Error ... BadWindow``. Raise a
+    clear, catchable error instead (see `issue #445
+    <https://github.com/pyvista/pyvistaqt/issues/445>`_).
+    """
+    if off_screen:  # no window is embedded, so no X11/Wayland surface clash
+        return
+    # QApplication.instance() is typed as the QCoreApplication base class, which
+    # has no platformName(); for a widgets app it is really a QApplication.
+    app = cast("QApplication | None", QApplication.instance())
+    if app is None:  # pragma: no cover
+        return
+    platform_name = app.platformName()
+    if not platform_name.startswith("wayland"):
+        return
+    msg = (
+        "pyvistaqt cannot render on-screen with the native Wayland Qt platform "
+        f"plugin (QApplication.platformName()={platform_name!r}): VTK embeds "
+        "via an X11 render window, which aborts with 'X Error ... BadWindow' on "
+        "a Wayland surface (https://github.com/pyvista/pyvistaqt/issues/445). "
+        "Set the environment variable QT_QPA_PLATFORM=xcb *before* the "
+        "QApplication is created to use XWayland, e.g. at the top of your "
+        "script:\n"
+        "    import os\n"
+        "    os.environ['QT_QPA_PLATFORM'] = 'xcb'"
+    )
+    raise RuntimeError(msg)
 
 
 def _setup_off_screen(off_screen: bool | None = None) -> bool:  # noqa: FBT001

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -54,7 +54,9 @@ from pyvistaqt.plotting import QTimer
 from pyvistaqt.plotting import QVTKRenderWindowInteractor
 from pyvistaqt.utils import _TERMINAL_OUTPUT_GUARDS
 from pyvistaqt.utils import _check_type
+from pyvistaqt.utils import _check_wayland
 from pyvistaqt.utils import _create_menu_bar
+from pyvistaqt.utils import _prefer_xcb_on_wayland
 from pyvistaqt.utils import _setup_application
 from pyvistaqt.utils import _setup_terminal_output_fix
 from pyvistaqt.utils import _TerminalOpostGuard
@@ -108,6 +110,86 @@ def test_create_menu_bar(qtbot) -> None:  # noqa: D103
 
 def test_setup_application(qapp) -> None:  # noqa: D103
     _setup_application(qapp)
+
+
+class _FakeApp:
+    """Minimal stand-in for a ``QApplication`` with a chosen platform name."""
+
+    def __init__(self, platform_name: str) -> None:
+        self._platform_name = platform_name
+
+    def platformName(self) -> str:  # noqa: N802
+        return self._platform_name
+
+
+def _patch_qapplication(monkeypatch, instance) -> None:
+    """Make ``pyvistaqt.utils.QApplication.instance()`` return ``instance``."""
+
+    class _FakeQApplication:
+        @staticmethod
+        def instance():  # noqa: ANN205
+            return instance
+
+    monkeypatch.setattr(pyvistaqt.utils, "QApplication", _FakeQApplication)
+
+
+@pytest.mark.parametrize(
+    ("wayland", "display", "pinned", "expected"),
+    [
+        ("wayland-0", ":0", None, "xcb"),  # Wayland + XWayland, not pinned -> xcb
+        ("wayland-0", ":0", "", "xcb"),  # empty override is treated as not pinned
+        ("wayland-0", ":0", "wayland", "wayland"),  # explicit choice is respected
+        ("wayland-0", "", None, None),  # no XWayland to fall back to -> untouched
+        (None, ":0", None, None),  # not a Wayland session -> untouched
+    ],
+)
+def test_prefer_xcb_on_wayland(monkeypatch, wayland, display, pinned, expected) -> None:
+    """``_prefer_xcb_on_wayland`` forces xcb only inside the context, then restores."""
+    _patch_qapplication(monkeypatch, None)  # no QApplication created yet
+    monkeypatch.delenv("QT_QPA_PLATFORM", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    if wayland is not None:
+        monkeypatch.setenv("WAYLAND_DISPLAY", wayland)
+    if display:
+        monkeypatch.setenv("DISPLAY", display)
+    if pinned is not None:
+        monkeypatch.setenv("QT_QPA_PLATFORM", pinned)
+    original = os.environ.get("QT_QPA_PLATFORM")
+    with _prefer_xcb_on_wayland():
+        assert os.environ.get("QT_QPA_PLATFORM") == expected
+    # the environment is always restored to its original state on exit
+    assert os.environ.get("QT_QPA_PLATFORM") == original
+
+
+def test_prefer_xcb_on_wayland_noop_if_app_exists(monkeypatch) -> None:
+    """Once a QApplication exists the platform plugin is fixed, so do nothing."""
+    _patch_qapplication(monkeypatch, _FakeApp("wayland"))
+    monkeypatch.delenv("QT_QPA_PLATFORM", raising=False)
+    monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+    monkeypatch.setenv("DISPLAY", ":0")
+    with _prefer_xcb_on_wayland():
+        assert "QT_QPA_PLATFORM" not in os.environ
+    assert "QT_QPA_PLATFORM" not in os.environ
+
+
+def test_check_wayland_raises_on_native_wayland(monkeypatch) -> None:
+    """On-screen setup on a native Wayland plugin fails early with guidance."""
+    _patch_qapplication(monkeypatch, _FakeApp("wayland"))
+    with pytest.raises(RuntimeError, match="native Wayland"):
+        _check_wayland(off_screen=False)
+
+
+def test_check_wayland_allows_offscreen(monkeypatch) -> None:
+    """Off-screen rendering embeds no surface, so it is always allowed."""
+    _patch_qapplication(monkeypatch, _FakeApp("wayland"))
+    _check_wayland(off_screen=True)  # must not raise
+
+
+def test_check_wayland_allows_xcb(monkeypatch) -> None:
+    """The xcb (X11/XWayland) plugin is supported and must not raise."""
+    _patch_qapplication(monkeypatch, _FakeApp("xcb"))
+    _check_wayland(off_screen=False)  # must not raise
 
 
 def test_setup_terminal_output_fix_noop_when_not_interactive(qapp) -> None:


### PR DESCRIPTION
While we look for a real fix for #445, we can a) try to create QApplication using `xcb` if one isn't specified, and b) raise an error if people try to use QtInteractor on Wayland.