### PR TITLE
Use `BackgroundPlotter.deleteAfter()` in `close`, and use refleak to find, detect, and eliminate leaks

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytest-cov
   - pytest-qt
   - qtpy>=1.9.0
+  - refleak>=0.2.1
   - scooby>=0.5.1
   - pip
   - pip:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ test = [
     # Pull in whatever trame/nest_asyncio stack the installed pyvista needs
     # for VTKjs export. Each pyvista version pins its own compatible deps.
     "pyvista[jupyter]",
+    "refleak==0.2.1",
     "scooby==0.11.2",
     "sphinx_gallery==0.21.0",
 ]

--- a/pyvistaqt/plotting.py
+++ b/pyvistaqt/plotting.py
@@ -663,6 +663,11 @@ class BackgroundPlotter(QtInteractor):
             LOG.debug("BackgroundPlotter.close app_window.close()")
             with contextlib.suppress(Exception):  # pragma: no cover
                 self.app_window.close()
+                # Schedule the window (and its child menus/toolbars/editor)
+                # for deletion. Otherwise those Qt objects outlive the close
+                # and their signal connections keep the closures they hold --
+                # which capture ``self`` -- alive, leaking the whole plotter.
+                self.app_window.deleteLater()
             LOG.debug("BackgroundPlotter.close done")
 
     def _close(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,12 @@
 from __future__ import annotations  # noqa: D100
 
 import gc
-import inspect
 
 import pytest
 import pyvista
 from pyvista.plotting import system_supports_plotting
+from refleak.testing import Snapshot
+from refleak.testing import gc_collect_once
 
 NO_PLOTTING = not system_supports_plotting()
 
@@ -16,68 +17,94 @@ def pytest_configure(config) -> None:
     for fixture in ("check_gc",):
         config.addinivalue_line("usefixtures", fixture)
     # Markers
-    for marker in ("allow_bad_gc", "allow_bad_gc_pyside", "slow"):
+    for marker in (
+        "allow_bad_gc: skip the VTK/plotter leak check for this test",
+        "slow: mark a test as slow",
+    ):
         config.addinivalue_line("markers", marker)
 
 
-# Adapted from PyVista
-def _is_vtk(obj):  # noqa: ANN202
+_phase_report_key = pytest.StashKey()
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):  # noqa: ANN201, ARG001
+    """Stash per-phase reports so fixtures can skip GC checks on failure."""
+    outcome = yield
+    rep = outcome.get_result()
+    item.stash.setdefault(_phase_report_key, {})[rep.when] = rep
+
+
+def _test_passed(request) -> bool:
+    report = request.node.stash.get(_phase_report_key, {})
+    return "call" in report and report["call"].outcome == "passed"
+
+
+_vtk_object_base = None
+
+
+def _is_vtk(obj) -> bool:
+    """
+    Check if an object is a VTK object (wrappers and subclasses included).
+
+    An ``isinstance`` check, not a class-name-prefix one: VTK >= 9.6
+    instantiates pythonic override subclasses whose names lack the ``vtk``
+    prefix (``PolyData``, ``VTKAOSArray_vtkFloatArray``, ...).
+    """
+    global _vtk_object_base  # noqa: PLW0603
+    if _vtk_object_base is None:
+        from vtkmodules.vtkCommonCore import vtkObjectBase  # noqa: PLC0415
+
+        _vtk_object_base = vtkObjectBase
+    return isinstance(obj, _vtk_object_base)
+
+
+def _drain_qt_events() -> None:
+    """Flush pending Qt work, including deferred (deleteLater) deletions."""
     try:
-        return obj.__class__.__name__.startswith("vtk")
-    except Exception:  # old Python sometimes no __class__.__name__  # noqa: BLE001
-        return False
+        from qtpy.QtCore import QEvent  # noqa: PLC0415
+        from qtpy.QtWidgets import QApplication  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return
+    app = QApplication.instance()
+    if app is None:
+        return
+    for _ in range(2):
+        app.processEvents()
+        app.sendPostedEvents(None, QEvent.DeferredDelete)
 
 
 @pytest.fixture(autouse=True)
-def check_gc(request):  # noqa: ANN201, C901
-    """Ensure that all VTK objects are garbage-collected by Python."""
-    if "test_ipython" in request.node.name:  # XXX this keeps a ref  # noqa: FIX003, TD001, TD002, TD003, TD004
-        yield
-        return
-    try:
-        from qtpy import API_NAME  # noqa: PLC0415
-    except Exception:  # noqa: BLE001
-        API_NAME = ""  # noqa: N806
+def check_gc(request):  # noqa: ANN201
+    """Ensure that all VTK objects created during a test are GC'ed."""
     marks = {mark.name for mark in request.node.iter_markers()}
     if "allow_bad_gc" in marks:
         yield
         return
-    if "allow_bad_gc_pyside" in marks and API_NAME.lower().startswith("pyside"):
-        yield
-        return
+    from pyvistaqt import QtInteractor  # noqa: PLC0415
+
+    # Snapshots so that leftovers of earlier tests that legitimately skip
+    # this check (e.g. the IPython shell singleton pinning its plotter) are
+    # not blamed on this test.
     gc.collect()
-    before = {id(o) for o in gc.get_objects() if _is_vtk(o)}
+    objs = gc.get_objects()  # scan the heap once, share across snapshots
+    snap_qt = Snapshot(QtInteractor, objs=objs)
+    snap_vtk = Snapshot(_is_vtk, label="VTK", objs=objs)
+    del objs
     yield
     pyvista.close_all()
-    gc.collect()
-    after = [o for o in gc.get_objects() if _is_vtk(o) and id(o) not in before]
-    msg = "Not all objects GCed:\n"
-    for obj in after:
-        cn = obj.__class__.__name__
-        cf = inspect.currentframe()
-        referrers = [v for v in gc.get_referrers(obj) if v is not after and v is not cf]
-        del cf
-        for ri, referrer in enumerate(referrers):
-            if isinstance(referrer, dict):
-                for k, v in referrer.items():
-                    if k is obj:
-                        referrers[ri] = "dict: d key"
-                        del k, v
-                        break
-                    elif v is obj:
-                        referrers[ri] = f"dict: d[{k!r}]"
-                        # raise RuntimeError(referrers[ri])  # noqa: ERA001
-                        del k, v
-                        break
-                    del k, v
-                else:
-                    referrers[ri] = f"dict: len={len(referrer)}"
-            else:
-                referrers[ri] = repr(referrer)
-            del ri, referrer
-        msg += f"{cn}: {referrers}\n"
-        del cn, referrers
-    assert len(after) == 0, msg
+    _drain_qt_events()
+    if not _test_passed(request):
+        return
+    when = f"teardown of {request.node.name}"
+    gc_collect_once(request)
+    objs = gc.get_objects()
+    # No plotter/interactor created during a test may survive it
+    # (BackgroundPlotter is a QtInteractor subclass, so this covers both) ...
+    snap_qt.assert_no_new(when, request=request, objs=objs)
+    # ... and neither may any VTK object created during the test.
+    snap_vtk.assert_no_new(when, request=request, objs=objs)
+    del objs
 
 
 @pytest.fixture

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -8,6 +8,7 @@ import os.path as op
 import platform
 import re
 import sys
+import threading
 import weakref
 
 import numpy as np
@@ -743,8 +744,16 @@ def test_background_plotting_orbit(qtbot, plotting) -> None:  # noqa: ARG001, D1
     plotter = BackgroundPlotter(off_screen=False, title="Testing Window")
     plotter.add_mesh(pyvista.Sphere())
     # perform the orbit:
+    threads_before = set(threading.enumerate())
     plotter.orbit_on_path(threaded=True, step=0.0)
     plotter.close()
+    # Released pyvista's threaded orbit is fire-and-forget and close() does
+    # not stop it (pyvista#8804 does); on macOS every render() also spawns a
+    # thread. A still-running thread's frame holds the plotter, tripping
+    # check_gc on runners slow enough for the orbit to outlive the test
+    # (macOS Intel), so wait for every thread the orbit spawned.
+    for thread in set(threading.enumerate()) - threads_before:
+        thread.join(timeout=10)
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="#508")

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,6 +1,7 @@
 from __future__ import annotations  # noqa: D100
 
 from contextlib import nullcontext
+import gc
 import logging
 import os
 import os.path as op
@@ -221,6 +222,8 @@ def test_mouse_interactions(qtbot, debug_log_level) -> None:  # noqa: D103,ARG00
     plotter.close()
 
 
+# The IPython InteractiveShell singleton keeps the session's objects alive
+@pytest.mark.allow_bad_gc
 def test_ipython(qapp) -> None:  # noqa: ARG001, D103
     IPython = pytest.importorskip("IPython")  # noqa: N806
     cmd = "from pyvistaqt import BackgroundPlotter as Plotter;p = Plotter(show=False, off_screen=False); p.close(); exit()"
@@ -293,25 +296,20 @@ def test_counter(qtbot) -> None:  # noqa: D103
     assert counter.count == 0
 
 
-# TODO: Fix gc on PySide6  # noqa: FIX002, TD002, TD003
 @pytest.mark.parametrize("border", [True, False])
-@pytest.mark.allow_bad_gc_pyside
 def test_subplot_gc(border) -> None:  # noqa: D103
     plotter = BackgroundPlotter(shape=(2, 1), update_app_icon=False, border=border)
     plotter.close()  # TODO: Should automatically close but need it on macOS + PySide6!  # noqa: FIX002, TD002, TD003
 
 
-@pytest.mark.allow_bad_gc_pyside
 def test_editor(qtbot, plotting) -> None:  # noqa: ARG001, D103
     print("test editor=False")
     plotter = BackgroundPlotter(editor=False, off_screen=False)
-    qtbot.addWidget(plotter.app_window)
     assert plotter.editor is None
     plotter.close()
 
     print("test editor closing")
     plotter = BackgroundPlotter(editor=True, off_screen=False)
-    qtbot.addWidget(plotter.app_window)
     assert_hasattr(plotter, "editor", Editor)
     editor = plotter.editor
     assert not editor.isVisible()
@@ -326,7 +324,6 @@ def test_editor(qtbot, plotting) -> None:  # noqa: ARG001, D103
 
     print("editor=True by default")
     plotter = BackgroundPlotter(shape=(2, 1), off_screen=False)
-    qtbot.addWidget(plotter.app_window)
     editor = plotter.editor
     with wait_exposed(qtbot, editor):
         editor.toggle()
@@ -566,6 +563,28 @@ def test_background_plotting_camera(qtbot, plotting) -> None:  # noqa: ARG001, D
     plotter.close()
 
 
+def test_background_plotting_close_gc(qtbot, plotting) -> None:  # noqa: ARG001
+    """
+    A closed BackgroundPlotter must be garbage-collected.
+
+    Regression test: the toolbars/menu/editor hold closures capturing the
+    plotter, kept alive by the app window's Qt objects. ``close()`` schedules
+    the window for deletion so those objects (and their closures) go away,
+    breaking the cycle. Without that, the plotter leaks.
+    """
+    plotter = BackgroundPlotter(off_screen=False, title="Testing Window")
+    plotter.add_mesh(pyvista.Sphere(), scalars=pyvista.Sphere().points[:, 0])
+    plotter.save_camera_position()
+    ref = weakref.ref(plotter)
+    plotter.close()
+    del plotter
+    # process the scheduled (deleteLater) deletions, then collect
+    for _ in range(3):
+        qtbot.wait(10)
+        gc.collect()
+    assert ref() is None
+
+
 @pytest.mark.parametrize("other_views", [None, 0, [0]])
 def test_link_views_across_plotters(other_views) -> None:  # noqa: D103
     def _to_array(camera_position):  # noqa: ANN202
@@ -658,6 +677,8 @@ def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting) 
     assert not window.isVisible()
 
 
+# The trame/VTKjs export path attaches a TrameComponent that holds a strong
+# reference to the plotter, so it (and its VTK objects) outlive the test.
 @pytest.mark.allow_bad_gc
 def test_background_plotter_export_vtkjs(qtbot, tmpdir, plotting) -> None:  # noqa: ARG001, D103
     # VTKjs export is only guaranteed on current pyvista + VTK.
@@ -718,8 +739,6 @@ def test_background_plotter_export_vtkjs(qtbot, tmpdir, plotting) -> None:  # no
         assert os.path.isfile(filename + ext)  # noqa: PTH113
 
 
-# vtkWeakReference and vtkFloatArray, only sometimes -- usually macOS
-@pytest.mark.allow_bad_gc
 def test_background_plotting_orbit(qtbot, plotting) -> None:  # noqa: ARG001, D103
     plotter = BackgroundPlotter(off_screen=False, title="Testing Window")
     plotter.add_mesh(pyvista.Sphere())
@@ -763,8 +782,6 @@ def test_background_plotting_toolbar(qtbot, plotting) -> None:  # noqa: ARG001, 
     plotter.close()
 
 
-# TODO: _render_passes not GC'ed  # noqa: FIX002, TD002, TD003
-@pytest.mark.allow_bad_gc_pyside
 @pytest.mark.skipif(platform.system() == "Windows", reason="Segfaults on Windows")
 def test_background_plotting_menu_bar(qtbot, plotting) -> None:  # noqa: ARG001, D103
     print("Bad call")
@@ -954,19 +971,13 @@ def test_background_plotting_add_callback(qtbot, monkeypatch, plotting) -> None:
     assert not callback_timer.isActive()  # window stops the callback
 
 
-# TODO: Need to fix this allow_bad_gc:  # noqa: FIX002, TD002, TD003
-# - the actors are not cleaned up in the non-empty scene case
-# - the q_key_press leaves a lingering vtkUnsignedCharArray referred to by
-#   a "managedbuffer" object
-@pytest.mark.allow_bad_gc
 @pytest.mark.slow
-@pytest.mark.allow_bad_gc_pyside
 @pytest.mark.parametrize(
     "close_event",
     [
         "plotter_close",
         "window_close",
-        pytest.param("q_key_press", marks=pytest.mark.allow_bad_gc),
+        pytest.param("q_key_press"),
         "menu_exit",
         "del_finalizer",
     ],


### PR DESCRIPTION
I recently peeled off MNE-Python's reference-cycle hunting code into [refleak](https://github.com/mne-tools/refleak). With that and Claude Opus 4.8, figured out that `self.app_window.deleteLater()` was a critical component to removing some reference issues. The two remaining `allow_bad_gc`s are 1) in

1. `test_ipython` because IPython's InteractiveShell singleton pins the session, and
2. test_background_plotter_export_vtkjs, as trame's TrameComponent holds a strong ref to the plotter

I'll go ahead and merge once CIs are clean since this seems like a clear win :rocket: 

Closes #414