### PR TITLE
FIX: Remove VTK observer pins and drop the allow_bad_gc marker

### DIFF
--- a/pyvistaqt/rwi.py
+++ b/pyvistaqt/rwi.py
@@ -288,10 +288,20 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
         self._Timer = QTimer(self)
         self._Timer.timeout.connect(self.TimerEvent)
 
-        self._Iren.AddObserver('CreateTimerEvent', self.CreateTimer)
-        self._Iren.AddObserver('DestroyTimerEvent', self.DestroyTimer)
-        self._Iren.GetRenderWindow().AddObserver('CursorChangedEvent',
-                                                 self.CursorChangedEvent)
+        # Track (subject, tag) pairs so teardown can remove the observers:
+        # VTK holds a C++-side strong reference to each bound method, which
+        # pins the widget (invisibly to Python's GC) for as long as the
+        # subject lives -- a leak whenever anything (e.g. a trame export)
+        # keeps the render window alive past close.
+        self._vtk_observers = [
+            (self._Iren,
+             self._Iren.AddObserver('CreateTimerEvent', self.CreateTimer)),
+            (self._Iren,
+             self._Iren.AddObserver('DestroyTimerEvent', self.DestroyTimer)),
+            (self._RenderWindow,
+             self._RenderWindow.AddObserver('CursorChangedEvent',
+                                            self.CursorChangedEvent)),
+        ]
 
         # If we've a parent, it does not close the child when closed.
         # Connect the parent's destroyed signal to this widget's close
@@ -314,6 +324,12 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
         Call internal cleanup method on VTK objects
         '''
         self._RenderWindow.Finalize()
+
+    def _remove_observers(self):
+        """Drop VTK's C++-side references to our bound methods."""
+        observers, self._vtk_observers = self._vtk_observers, []
+        for obj, tag in observers:
+            obj.RemoveObserver(tag)
 
     def CreateTimer(self, obj, evt):
         self._Timer.start(10)
@@ -344,6 +360,16 @@ class QVTKRenderWindowInteractor(QVTKRWIBaseClass):
 
     def closeEvent(self, evt):
         self.Finalize()
+        self._remove_observers()
+
+    def close(self):
+        result = super().close()  # delivers closeEvent to realized widgets
+        # Qt never delivers closeEvent to a widget that was never realized
+        # (e.g. constructed with show=False), so tear down here as well; both
+        # calls are idempotent.
+        self.Finalize()
+        self._remove_observers()
+        return result
 
     def sizeHint(self):
         return QSize(400, 400)

--- a/pyvistaqt/window.py
+++ b/pyvistaqt/window.py
@@ -1,5 +1,7 @@
 """This module contains a Qt-compatible MainWindow class."""  # noqa: D404
 
+import contextlib
+
 from qtpy import QtCore
 from qtpy.QtCore import Signal
 from qtpy.QtWidgets import QMainWindow
@@ -31,6 +33,26 @@ class MainWindow(QMainWindow):
             self.signal_gesture.emit(event)
             return True
         return super().event(event)
+
+    def close(self) -> bool:
+        """
+        Close the window, tolerating an already-deleted Qt object.
+
+        ``BackgroundPlotter.close`` schedules this window for deferred
+        deletion (``deleteLater``); a later ``close()`` -- e.g. pytest-qt
+        closing registered widgets at teardown -- would then raise from the
+        dead C++ object.
+        """
+        try:
+            return super().close()
+        except RuntimeError:  # C++ object already deleted (PySide/PyQt)
+            return True
+
+    def deleteLater(self) -> None:  # noqa: N802
+        """Schedule deletion, tolerating an already-deleted Qt object (see close)."""
+        # C++ object may already be deleted (PySide/PyQt)
+        with contextlib.suppress(RuntimeError):
+            super().deleteLater()
 
     def closeEvent(self, event: QtCore.QEvent) -> None:  # noqa: N802
         """Manage the close event."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,11 +17,7 @@ def pytest_configure(config) -> None:
     for fixture in ("check_gc",):
         config.addinivalue_line("usefixtures", fixture)
     # Markers
-    for marker in (
-        "allow_bad_gc: skip the VTK/plotter leak check for this test",
-        "slow: mark a test as slow",
-    ):
-        config.addinivalue_line("markers", marker)
+    config.addinivalue_line("markers", "slow: mark a test as slow")
 
 
 _phase_report_key = pytest.StashKey()
@@ -77,15 +73,10 @@ def _drain_qt_events() -> None:
 @pytest.fixture(autouse=True)
 def check_gc(request):  # noqa: ANN201
     """Ensure that all VTK objects created during a test are GC'ed."""
-    marks = {mark.name for mark in request.node.iter_markers()}
-    if "allow_bad_gc" in marks:
-        yield
-        return
     from pyvistaqt import QtInteractor  # noqa: PLC0415
 
-    # Snapshots so that leftovers of earlier tests that legitimately skip
-    # this check (e.g. the IPython shell singleton pinning its plotter) are
-    # not blamed on this test.
+    # Snapshots so that process-lifetime leftovers (e.g. session-scoped
+    # fixtures, the trame server singleton) are not blamed on this test.
     gc.collect()
     objs = gc.get_objects()  # scan the heap once, share across snapshots
     snap_qt = Snapshot(QtInteractor, objs=objs)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # noqa: D100
 
+import contextlib
 from contextlib import nullcontext
 import gc
 import logging
@@ -223,11 +224,9 @@ def test_mouse_interactions(qtbot, debug_log_level) -> None:  # noqa: D103,ARG00
     plotter.close()
 
 
-# The IPython InteractiveShell singleton keeps the session's objects alive
-@pytest.mark.allow_bad_gc
 def test_ipython(qapp) -> None:  # noqa: ARG001, D103
     IPython = pytest.importorskip("IPython")  # noqa: N806
-    cmd = "from pyvistaqt import BackgroundPlotter as Plotter;p = Plotter(show=False, off_screen=False); p.close(); exit()"
+    cmd = "from pyvistaqt import BackgroundPlotter as Plotter;p = Plotter(show=False, off_screen=False); p.close(); del p; exit()"
     IPython.start_ipython(argv=["-c", cmd])
 
 
@@ -678,15 +677,56 @@ def test_background_plotter_export_files(qtbot, tmpdir, show_plotter, plotting) 
     assert not window.isVisible()
 
 
-# The trame/VTKjs export path attaches a TrameComponent that holds a strong
-# reference to the plotter, so it (and its VTK objects) outlive the test.
-@pytest.mark.allow_bad_gc
-def test_background_plotter_export_vtkjs(qtbot, tmpdir, plotting) -> None:  # noqa: ARG001, D103
+@pytest.fixture(scope="session")
+def _trame_server(tmp_path_factory) -> None:
+    """
+    Launch the process-lifetime trame server outside any GC snapshot.
+
+    The first vtksz export launches a trame server singleton whose helper
+    keeps a ``vtkWebApplication`` (and its protocol objects) alive for the
+    rest of the process by design; warm it up once so ``check_gc`` does not
+    blame those objects on the first exporting test.
+    """
     # VTKjs export is only guaranteed on current pyvista + VTK.
     # Older pyvista (< 0.47) still imports the deprecated `nest_asyncio`
     # package and older VTK may lack APIs that trame-vtk relies on.
     pytest.importorskip("pyvista", minversion="0.47")
     pytest.importorskip("vtk", minversion="9.6")
+    with contextlib.suppress(ImportError):
+        import trame_pyvista  # noqa: F401, PLC0415
+    plotter = pyvista.Plotter(off_screen=True)
+    plotter.add_mesh(pyvista.Cone())
+    trame = getattr(plotter, "trame", None)
+    if trame is not None and hasattr(trame, "export_vtksz"):
+        trame.export_vtksz(filename=None)  # pyvista >= 0.49 (trame-pyvista)
+    else:
+        plotter.export_vtksz(str(tmp_path_factory.mktemp("trame") / "warmup.vtksz"))
+    plotter.close()
+
+
+@pytest.fixture
+def trame_array_cache(_trame_server, check_gc) -> None:  # noqa: ARG001
+    """
+    Clear trame's serializer cache before ``check_gc``'s teardown check.
+
+    The (session-lifetime) ``SynchronizationContext`` caches every exported
+    data array and only releases them via a 20-second time window, so the
+    exporting test's arrays would otherwise survive it.
+    """
+    yield
+    from trame_vtk.modules.vtk import HELPERS_PER_SERVER  # noqa: PLC0415
+
+    for helper in HELPERS_PER_SERVER.values():
+        protocol = helper._root_protocol  # noqa: SLF001
+        if protocol is None:
+            continue
+        for link_protocol in protocol.getLinkProtocols():
+            context = getattr(link_protocol, "context", None)
+            if context is not None:
+                context.data_array_cache.clear()
+
+
+def test_background_plotter_export_vtkjs(qtbot, tmpdir, plotting, trame_array_cache) -> None:  # noqa: ARG001, D103
     # setup filesystem
     output_dir = str(tmpdir.mkdir("tmpdir"))
     assert os.path.isdir(output_dir)  # noqa: PTH112


### PR DESCRIPTION
Three independent leaks/failures kept tests on the VTK/plotter GC check's allow list; fix them and remove the marker entirely:

- QVTKRenderWindowInteractor bound-method observers: VTK holds a C++-side strong reference to each. Track the (subject, tag) pairs and remove them at teardown, including for never-realized widgets (show=False)
- trame server keeps a vtkWebApplication alive for the rest of the process by design, and its SynchronizationContext caches every exported data array behind a 20-second release window. Warm the server up in a session fixture so it pre-exists the GC snapshot, and clear the array cache before the check.
- MainWindow.close()/deleteLater() now tolerate an already-deleted C++ object: BackgroundPlotter.close schedules the window for deferred deletion, and pytest-qt's teardown then calls close() on the dead wrapper (RuntimeError under PySide and PyQt).
- test_ipython: del the plotter from the IPython user namespace; the InteractiveShell singleton otherwise pins it (and its VTK objects).